### PR TITLE
[ci] unattended PR review (self-test)

### DIFF
--- a/.fragua/workflows/pr_review.yaml
+++ b/.fragua/workflows/pr_review.yaml
@@ -1,0 +1,132 @@
+# pr_review.yaml — unattended PR review for CI: scope-and-classify → review
+# scaled to the change → post the review back to the PR. NO human gate.
+#
+# The non-HITL sibling of `review`. Where `review` ends at a `signoff` human
+# step that authorizes the PR action, `pr_review` runs to completion under
+# `fragua ci pr_review --input pr=<n>` and posts the review itself:
+# `gh pr review --request-changes` when the pass surfaces a Critical or High
+# finding, `--comment` otherwise. The classifier still scales depth
+# (skip/quick/full) so a typo PR never draws an Opus full pass.
+#
+# Runs in the CI checkout's worktree: the PR's files are already on disk (read
+# them directly) and `gh pr diff <n>` gives the diff. Needs GH_TOKEN in env for
+# the gh calls (pr-review.yml sets it) plus a provider credential. There is no
+# human to authorize the post — that is the whole point of this variant, and
+# why it only ever requests-changes or comments (never approves).
+#
+#   fragua ci pr_review --input pr=128
+
+name: pr_review
+goal: Unattended PR review for CI — review scaled to the change, posted back to the PR with no human gate.
+budget: 2.50
+
+inputs:
+  pr:
+    type: string
+    required: true
+    description: PR number to review (e.g. 128)
+
+defaults:
+  provider: anthropic
+  model: claude-sonnet-4-6
+
+steps:
+  scope:                               # resolve the PR diff + size the change; routes
+    type: llm
+    thread: review
+    allowed-tools: [read, grep, find, bash]
+    max-cost: 0.40
+    prompt: |
+      Review PR #${{ inputs.pr }}. Its files are already checked out on disk — read them directly. Get the diff with `gh pr diff ${{ inputs.pr }}` and metadata with `gh pr view ${{ inputs.pr }} --json baseRefName,title`.
+
+      Empty or failing diff → `abort` with `no diff for PR ${{ inputs.pr }}`.
+
+      Emit (no preamble, ≤8 lines):
+        PR: ${{ inputs.pr }}
+        TITLE: <pr title>
+        BASE: <base branch>
+        PATHS: <comma-sep, real on-disk, repo-relative>
+        LOC: <approx>
+        FOCUS: general
+
+      Then size the change and call the `route` tool once (state the deciding factor in one line first):
+        skip  — doc-only / typo / whitespace / comments / generated / version-bump; no semantic code change
+        quick — small, single-concern change (a contained fix or minor change)
+        full  — feature-scale, cross-cutting, or risk-bearing (auth / input parsing / data layer / shared contracts / large diff)
+
+      For `skip`, that one line is the whole review — make it a clean `LGTM: <reason>`.
+    routes:
+      skip:  {to: post,         label: "Trivial"}
+      quick: {to: review_quick, label: "Quick review"}
+      full:  {to: review_full,  label: "Full review"}
+
+  review_quick:                        # quick tier — one focused pass
+    type: llm
+    thread: review
+    allowed-tools: [read, grep, bash]
+    max-cost: 0.40
+    next: post
+    prompt: |
+      Quick review of PR #${{ inputs.pr }} (`gh pr diff ${{ inputs.pr }}`; read the changed files directly). One focused pass over correctness and any obvious security or clarity issue — it's a small change, keep it to a single pass. Emit verbatim:
+
+      # Code Review
+
+      ## Findings
+      One per line: `- [critical|high|medium|low] path:line — claim.` with `Why:` and `Fix:` each one sentence. If none, replace with `## All clear` + one sentence (what was reviewed, what you couldn't see).
+
+      ## Next steps
+      ≤2 concrete actions, or `No follow-up required.`
+
+  review_full:                         # full tier — one deep pass over the implicated lenses
+    type: llm
+    model: claude-opus-4-7
+    effort: high
+    thread: review
+    allowed-tools: [read, grep, bash]
+    max-cost: 1.80
+    next: verify
+    prompt: |
+      Deep review of PR #${{ inputs.pr }} (`gh pr diff ${{ inputs.pr }}`; read the changed files directly). Apply these lenses — correctness ALWAYS; add the others only when the diff implicates them, and say which you applied:
+
+        correctness — logic bugs, off-by-one, races, missing null checks, broken invariants, mishandled errors/promises, type unsoundness, dead branches, edge cases. Cross-check call sites where it matters.
+        security (iff trust boundaries / auth / input parsing / crypto / secrets touched) — injection (SQL/shell/XSS/path traversal), unvalidated input across trust boundaries, auth/authz gaps, secret leaks, unsafe deserialisation, weak crypto, SSRF; check surrounding sanitisation before flagging.
+        performance (iff hot paths / data layer / loops / large payloads touched) — complexity surprises (O(n²) on a hot path), N+1, unbounded work, blocking I/O on hot paths, oversized payloads; confidence ∝ evidence; no cold-path constant-factor nits.
+        architecture (iff cross-package coupling / public surface / abstraction boundaries change) — coupling crossing boundaries, leaky abstractions, SRP violations, drift-inviting duplication, misleading naming, public surface exposing internals, half-finished work, scope creep.
+
+      Then emit one ranked review verbatim. Headings exactly: `# Code Review` / `## Scope` / `## Critical` / `## High` / `## Medium` / `## Low`.
+
+      ## Scope: one paragraph naming the touched packages/areas and the change type; name which lenses you applied and why.
+
+      Per finding: **path:line** — one-line claim. `Why:` one sentence. `Fix:` one sentence or short snippet. `Lens:` which lens flagged it.
+
+      Rules: NO INVENTION. DROP subjective low findings with no evidence. A concern flagged under two lenses is ONE entry at the higher severity, noted `(cross-flagged)`.
+
+      If everything is clean, replace the severity sections with `## All clear` (one paragraph: what was reviewed, what you couldn't see, confidence).
+
+      End with `## Next steps` — ≤3 ordered actions, or `No follow-up required.`
+
+  verify:                              # full tier — automated evidence-quality gate
+    type: llm
+    thread: review
+    retry: review_full                 # REJECT ⇒ re-review (capped)
+    max-retries: 2
+    allowed-tools: [read, grep]
+    max-cost: 0.30
+    next: post
+    prompt: |
+      Evidence-quality gate for the review. Judge on its own merits.
+        1. Every finding's path:line is verifiable — spot-check 2-3 by reading the cited path.
+        2. Severity calibration sane (no low for misleading claims, no critical for nitpicks; cross-flagged ≥ high).
+        3. Schema followed — Scope present; severities ordered or replaced by All clear; Next steps present.
+      All pass → reply EXACTLY `APPROVE`. Else `abort` with `REJECT: <one-line worst violation>`.
+
+  post:                                # auto-post the review — request-changes if blocking, else comment
+    type: llm
+    thread: review
+    allowed-tools: [bash]
+    max-cost: 0.15
+    next: exit
+    prompt: |
+      The review is above in this thread. Post it to PR #${{ inputs.pr }}.
+      Write the review body to a temp file (heredoc). If the review has any Critical or High finding, `gh pr review ${{ inputs.pr }} --request-changes --body-file <tmp>`; otherwise `gh pr review ${{ inputs.pr }} --comment --body-file <tmp>`. Emit `POSTED: PR ${{ inputs.pr }} <changes|comment> <url>`.
+      If the gh call fails, `abort` with `post failed: <one-line reason>`.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,58 @@
+name: PR review
+
+# Unattended review on every push to a PR. Runs the `pr_review` fragua workflow
+# (`.fragua/workflows/pr_review.yaml`) to completion via `fragua ci` and posts
+# the result back to the PR: request-changes on a Critical/High finding,
+# comment otherwise. The job itself stays green either way — the review is
+# advisory; the PR's review state (not this check) is what gates a merge.
+#
+# This in-repo job builds fragua from source so it reviews the PR's own code
+# without depending on a published release. A CONSUMER repo wires the same
+# thing against a release binary in two lines — see
+# .github/actions/setup-fragua/README.md:
+#
+#     - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.1.0
+#     - run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write # the review posts itself back to the PR
+
+# A new commit on the PR cancels the review still running for the previous one
+# — no point spending tokens reviewing a head SHA that's already been replaced.
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Fork PRs don't receive secrets (no provider credential) and their
+    # GITHUB_TOKEN is read-only (can't post), so the review can neither run nor
+    # post — skip them. Same-repo PRs only.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history so the review can diff against base
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.17"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: "Review PR #${{ github.event.pull_request.number }}"
+        run: bun run fragua ci pr_review --input pr=${{ github.event.pull_request.number }}
+        env:
+          # Swap for ANTHROPIC_OAUTH_TOKEN to draw on a Claude subscription
+          # instead of API billing (setup-fragua/README.md § Credentials).
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }} # gh pr diff / view / review


### PR DESCRIPTION
Adds the unattended PR-review pipeline:

- `.fragua/workflows/pr_review.yaml` — the non-HITL sibling of `review` (scope → quick|full → verify → auto-post; no human gate).
- `.github/workflows/pr-review.yml` — runs it via `fragua ci pr_review --input pr=<n>` on every PR push (same-repo only); request-changes on a Critical/High finding, comment otherwise; cancel-in-progress on a new push.

**This PR is its own first live test** — `pull_request` workflows run from the PR head, so `pr-review.yml` here reviews this very diff end-to-end (env-cred seeding + `gh` auth + posting). If it posts a clean review and the job is green, it's validated; merging flips it on repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)