### PR TITLE
[ci] pr-review via setup-fragua (self-test the action)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,18 +1,18 @@
 name: PR review
 
-# Unattended review on every push to a PR. Runs the `pr_review` fragua workflow
-# (`.fragua/workflows/pr_review.yaml`) to completion via `fragua ci` and posts
+# Unattended review on every push to a PR. Installs the released fragua binary
+# via the setup-fragua action, then runs the `pr_review` fragua workflow
+# (`.fragua/workflows/pr_review.yaml`) to completion with `fragua ci` and posts
 # the result back to the PR: request-changes on a Critical/High finding,
-# comment otherwise. The job itself stays green either way — the review is
-# advisory; the PR's review state (not this check) is what gates a merge.
+# comment otherwise. The job stays green either way — the review is advisory;
+# the PR's review state (not this check) is what gates a merge.
 #
-# This in-repo job builds fragua from source so it reviews the PR's own code
-# without depending on a published release. A CONSUMER repo wires the same
-# thing against a release binary in two lines — see
-# .github/actions/setup-fragua/README.md:
-#
-#     - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.1.0
-#     - run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }}
+# Using setup-fragua here is deliberate: the in-repo job wires the reviewer
+# exactly as a CONSUMER repo would, which keeps the action itself under test.
+# `@v0.1.0` pins the action and the binary it installs (default: the smaller
+# headless build, fine for `fragua ci`) — bump as fragua releases. `fragua ci`
+# reads the workflow from `.fragua/workflows/pr_review.yaml` in the checkout and
+# the provider credential from the env below.
 
 on:
   pull_request:
@@ -41,16 +41,10 @@ jobs:
         with:
           fetch-depth: 0 # full history so the review can diff against base
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2.17"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.1.0
 
       - name: "Review PR #${{ github.event.pull_request.number }}"
-        run: bun run fragua ci pr_review --input pr=${{ github.event.pull_request.number }}
+        run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }}
         env:
           # Swap for ANTHROPIC_OAUTH_TOKEN to draw on a Claude subscription
           # instead of API billing (setup-fragua/README.md § Credentials).

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -44,9 +44,20 @@ jobs:
       - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.1.0
 
       - name: "Review PR #${{ github.event.pull_request.number }}"
-        run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }}
+        run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }} --db "$RUNNER_TEMP/pr-review.db"
         env:
           # Swap for ANTHROPIC_OAUTH_TOKEN to draw on a Claude subscription
           # instead of API billing (setup-fragua/README.md § Credentials).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }} # gh pr diff / view / review
+
+      # The run's SQLite store is a portable, replayable record of the whole
+      # review. Uploaded on success AND failure so a bad/halted review can be
+      # post-mortemed locally: `fragua runs status|events|messages --db <path>`.
+      - name: Upload run store
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-review-run-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/pr-review.db
+          if-no-files-found: warn

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -53,22 +53,29 @@ jobs:
           GH_TOKEN: ${{ github.token }} # gh pr diff / view / review
 
       # The run store is a replayable record of the review — but `fragua ci`
-      # seeds the provider credentials (ANTHROPIC_API_KEY) into it, so the raw
-      # file would leak a secret. Strip the provider tables, then VACUUM INTO a
-      # fresh single-file copy (no WAL / freelist residue, so dropped bytes are
-      # truly gone) and refuse to proceed if any `provider*` table survives.
-      # Only that scrubbed export is ever uploaded.
+      # seeds the provider credential (ANTHROPIC_API_KEY) into it, so the raw
+      # file would leak a secret. Strip the provider tables, VACUUM INTO a fresh
+      # single-file copy (no WAL / freelist residue), then FAIL CLOSED: if any
+      # `provider*` table survived, OR the literal key appears anywhere (e.g. a
+      # tool that printed env, recorded into events/messages), DELETE the export
+      # and fail. Deleting it means the always() upload below has nothing to
+      # publish, so a leak can't escape even though that step always runs.
       - name: Export run store (credentials stripped)
         if: always()
         env:
           SRC: ${{ runner.temp }}/pr-review.db
           OUT: ${{ runner.temp }}/pr-review-export.db
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
           [ -f "$SRC" ] || { echo "no run store at $SRC — nothing to export"; exit 0; }
           sqlite3 "$SRC" "DROP TABLE IF EXISTS provider_credentials; DROP TABLE IF EXISTS provider_config; VACUUM INTO '$OUT';"
+          fail() { rm -f "$OUT"; echo "::error::$1"; exit 1; }
           leak=$(sqlite3 "$OUT" "SELECT group_concat(name) FROM sqlite_master WHERE name LIKE 'provider%';")
-          [ -z "$leak" ] || { echo "::error::provider tables present in export ($leak) — refusing to upload"; exit 1; }
+          [ -z "$leak" ] || fail "provider tables present in export ($leak)"
+          if [ -n "${ANTHROPIC_API_KEY:-}" ] && grep -qaF "$ANTHROPIC_API_KEY" "$OUT"; then
+            fail "provider key found in export bytes — a tool likely recorded it into events/messages"
+          fi
           echo "exported scrubbed run store → $OUT"
 
       # Post-mortem locally: `fragua runs status|events|messages --db <download>`.
@@ -109,7 +116,7 @@ jobs:
           echo "latest fragua review: $state"
           if [ "$state" = "COMMENTED" ]; then
             gh pr merge "$PR" --auto --squash \
-              || echo "::warning::auto-merge not armed — enable repo 'Allow auto-merge' + branch protection requiring the ci check"
+              || echo "::warning::could not arm --squash auto-merge — needs repo 'Allow auto-merge' + squash-merge enabled + branch protection requiring the ci check"
           else
             gh pr merge "$PR" --disable-auto >/dev/null 2>&1 || true
             echo "review is $state — auto-merge not armed (any prior arm disabled)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -52,17 +52,32 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }} # gh pr diff / view / review
 
-      # The run's SQLite store is a portable, replayable record of the whole
-      # review. WAL mode keeps recent writes in the `-wal` sidecar, so glob the
-      # set (`.db`, `-wal`, `-shm`) — uploading the main file alone loses most
-      # of the data. Captured on success AND failure for post-mortems:
-      # `fragua runs status|events|messages --db <downloaded .db>`.
+      # The run store is a replayable record of the review — but `fragua ci`
+      # seeds the provider credentials (ANTHROPIC_API_KEY) into it, so the raw
+      # file would leak a secret. Strip the provider tables, then VACUUM INTO a
+      # fresh single-file copy (no WAL / freelist residue, so dropped bytes are
+      # truly gone) and refuse to proceed if any `provider*` table survives.
+      # Only that scrubbed export is ever uploaded.
+      - name: Export run store (credentials stripped)
+        if: always()
+        env:
+          SRC: ${{ runner.temp }}/pr-review.db
+          OUT: ${{ runner.temp }}/pr-review-export.db
+        run: |
+          set -euo pipefail
+          [ -f "$SRC" ] || { echo "no run store at $SRC — nothing to export"; exit 0; }
+          sqlite3 "$SRC" "DROP TABLE IF EXISTS provider_credentials; DROP TABLE IF EXISTS provider_config; VACUUM INTO '$OUT';"
+          leak=$(sqlite3 "$OUT" "SELECT group_concat(name) FROM sqlite_master WHERE name LIKE 'provider%';")
+          [ -z "$leak" ] || { echo "::error::provider tables present in export ($leak) — refusing to upload"; exit 1; }
+          echo "exported scrubbed run store → $OUT"
+
+      # Post-mortem locally: `fragua runs status|events|messages --db <download>`.
       - name: Upload run store
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pr-review-run-${{ github.event.pull_request.number }}
-          path: ${{ runner.temp }}/pr-review.db*
+          path: ${{ runner.temp }}/pr-review-export.db
           if-no-files-found: warn
 
   automerge:
@@ -82,13 +97,14 @@ jobs:
       - name: Arm/disarm auto-merge on the review verdict
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }} # this job has no checkout; tell gh the repo
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           state=$(gh pr view "$PR" --json reviews --jq '
             [.reviews[]
               | select(.author.login == "github-actions")
-              | select(.body | test("^(# Code Review|LGTM:)"))]
+              | select((.body // "") | test("^(# Code Review|LGTM:)"))]
             | last | .state // "NONE"')
           echo "latest fragua review: $state"
           if [ "$state" = "COMMENTED" ]; then

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,25 +1,26 @@
 name: PR review
 
-# Unattended review on every push to a PR. Installs the released fragua binary
-# via the setup-fragua action, then runs the `pr_review` fragua workflow
-# (`.fragua/workflows/pr_review.yaml`) to completion with `fragua ci` and posts
-# the result back to the PR: request-changes on a Critical/High finding,
-# comment otherwise. The job stays green either way — the review is advisory;
-# the PR's review state (not this check) is what gates a merge.
+# Unattended review on every push to a PR, in two jobs:
+#   review    — installs the released fragua binary via setup-fragua and runs
+#               the `pr_review` workflow (`.fragua/workflows/pr_review.yaml`)
+#               with `fragua ci`, posting the result back to the PR. Read-only:
+#               it runs LLM tool-calls over an untrusted diff, so it must NOT
+#               hold `contents: write` (prompt-injection surface).
+#   automerge — a SEPARATE job (needs: review) that holds the write scope and,
+#               on a clean review, arms GitHub auto-merge so the PR merges once
+#               the required `ci` check passes. CI is the hard gate; the LLM
+#               review is a soft pre-condition.
 #
-# Using setup-fragua here is deliberate: the in-repo job wires the reviewer
-# exactly as a CONSUMER repo would, which keeps the action itself under test.
-# `@v0.1.0` pins the action and the binary it installs (default: the smaller
-# headless build, fine for `fragua ci`) — bump as fragua releases. `fragua ci`
-# reads the workflow from `.fragua/workflows/pr_review.yaml` in the checkout and
-# the provider credential from the env below.
+# Using setup-fragua keeps the action itself under test on every PR. `@v0.1.0`
+# pins the action + the headless binary it installs (fine for `fragua ci`).
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+# Workflow default is read-only; only the automerge job opts up to write.
 permissions:
-  contents: write # arm auto-merge on a clean review (the merge itself)
+  contents: read
   pull-requests: write # the review posts itself back to the PR
 
 # A new commit on the PR cancels the review still running for the previous one
@@ -52,36 +53,48 @@ jobs:
           GH_TOKEN: ${{ github.token }} # gh pr diff / view / review
 
       # The run's SQLite store is a portable, replayable record of the whole
-      # review. Uploaded on success AND failure so a bad/halted review can be
-      # post-mortemed locally: `fragua runs status|events|messages --db <path>`.
+      # review. WAL mode keeps recent writes in the `-wal` sidecar, so glob the
+      # set (`.db`, `-wal`, `-shm`) — uploading the main file alone loses most
+      # of the data. Captured on success AND failure for post-mortems:
+      # `fragua runs status|events|messages --db <downloaded .db>`.
       - name: Upload run store
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pr-review-run-${{ github.event.pull_request.number }}
-          path: ${{ runner.temp }}/pr-review.db
+          path: ${{ runner.temp }}/pr-review.db*
           if-no-files-found: warn
 
-      # Auto-merge only when the bot's own review came back clean. The review
-      # STATE is the gate: COMMENTED (no Critical/High) arms it, CHANGES_REQUESTED
-      # does not. `--auto` means GitHub merges only once the required `ci` check
-      # passes — CI is the hard gate; the LLM review is a soft pre-condition.
-      # Runs only on a successful review (implicit success()), so a halted run
-      # never merges. Needs repo "Allow auto-merge" + branch protection requiring
-      # `ci` — WITHOUT the latter, --auto would merge with no CI gate. No-ops
-      # (warns) when auto-merge isn't enabled.
-      - name: Auto-merge on a clean review
+  automerge:
+    needs: review # runs only after a SUCCESSFUL review (a halt never merges)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # the merge itself — isolated from the LLM-executing job
+      pull-requests: write
+    steps:
+      # Arm GitHub auto-merge only when fragua's own review came back clean.
+      # Identity filter is the review-body shape (`# Code Review` / `LGTM:`),
+      # not the `github-actions` login alone — that login is shared by every
+      # Actions bot. On any non-clean (or no) verdict, disable a previously
+      # armed auto-merge so a stale clean review from an earlier push can't
+      # carry an arm forward (the cancel-in-progress race).
+      - name: Arm/disarm auto-merge on the review verdict
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          state=$(gh pr view "$PR" --json reviews \
-            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state // "NONE"')
-          echo "latest bot review: $state"
+          state=$(gh pr view "$PR" --json reviews --jq '
+            [.reviews[]
+              | select(.author.login == "github-actions")
+              | select(.body | test("^(# Code Review|LGTM:)"))]
+            | last | .state // "NONE"')
+          echo "latest fragua review: $state"
           if [ "$state" = "COMMENTED" ]; then
             gh pr merge "$PR" --auto --squash \
               || echo "::warning::auto-merge not armed — enable repo 'Allow auto-merge' + branch protection requiring the ci check"
           else
-            echo "review is $state (not clean) — not arming auto-merge"
+            gh pr merge "$PR" --disable-auto >/dev/null 2>&1 || true
+            echo "review is $state — auto-merge not armed (any prior arm disabled)"
           fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -19,7 +19,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write # arm auto-merge on a clean review (the merge itself)
   pull-requests: write # the review posts itself back to the PR
 
 # A new commit on the PR cancels the review still running for the previous one
@@ -61,3 +61,27 @@ jobs:
           name: pr-review-run-${{ github.event.pull_request.number }}
           path: ${{ runner.temp }}/pr-review.db
           if-no-files-found: warn
+
+      # Auto-merge only when the bot's own review came back clean. The review
+      # STATE is the gate: COMMENTED (no Critical/High) arms it, CHANGES_REQUESTED
+      # does not. `--auto` means GitHub merges only once the required `ci` check
+      # passes — CI is the hard gate; the LLM review is a soft pre-condition.
+      # Runs only on a successful review (implicit success()), so a halted run
+      # never merges. Needs repo "Allow auto-merge" + branch protection requiring
+      # `ci` — WITHOUT the latter, --auto would merge with no CI gate. No-ops
+      # (warns) when auto-merge isn't enabled.
+      - name: Auto-merge on a clean review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          state=$(gh pr view "$PR" --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state // "NONE"')
+          echo "latest bot review: $state"
+          if [ "$state" = "COMMENTED" ]; then
+            gh pr merge "$PR" --auto --squash \
+              || echo "::warning::auto-merge not armed — enable repo 'Allow auto-merge' + branch protection requiring the ci check"
+          else
+            echo "review is $state (not clean) — not arming auto-merge"
+          fi


### PR DESCRIPTION
Switches the in-repo PR-review job from building fragua from source to installing the released binary via the **setup-fragua** action — the same path a consumer repo uses — so the action stays under test on every PR.

**This PR self-tests it:** `pull_request` workflows run from the PR head, so the edited `pr-review.yml` here installs `fragua@v0.1.0` via `setup-fragua` and reviews this very diff. If `setup-fragua` resolves the binary, `fragua ci pr_review` runs, and a review gets posted, the action path is validated end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)