### PR TITLE
[ci,daemon] nightly: raise per-test timeout + deflake timer-fragile tests

### DIFF
--- a/.github/workflows/property-nightly.yml
+++ b/.github/workflows/property-nightly.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Property suite — shard ${{ matrix.shard }} (FRAGUA_PBT_RUNS=20×)
         env:
           FRAGUA_PBT_RUNS: "20"
-        run: bun test ./packages/store ./packages/daemon ./packages/core ./packages/agent
+        run: bun test --timeout 120000 ./packages/store ./packages/daemon ./packages/core ./packages/agent

--- a/packages/daemon/test/blob-gc.test.ts
+++ b/packages/daemon/test/blob-gc.test.ts
@@ -80,7 +80,14 @@ describe("startBlobGc", () => {
       intervalMs: 10,
       onSweep: (deleted) => sweeps.push(deleted),
     });
-    await new Promise((res) => setTimeout(res, 40));
+
+    // Poll until ≥2 calls land, then shut down. The 2s ceiling is generous
+    // enough to survive a saturated CI runner without weakening the assertion
+    // (the loop fires every 10ms; even at 100× slowdown it finishes well inside 2s).
+    const deadline = Date.now() + 2_000;
+    while (calls < 2 && Date.now() < deadline) {
+      await new Promise((res) => setTimeout(res, 10));
+    }
     ctrl.abort();
     await gc.promise;
 

--- a/packages/daemon/test/executor.timeout.test.ts
+++ b/packages/daemon/test/executor.timeout.test.ts
@@ -65,10 +65,18 @@ describe("classifyAbortCause", () => {
   });
 
   test("real AbortSignal.timeout propagated through AbortSignal.any", async () => {
-    const timeoutSignal = AbortSignal.timeout(5);
+    // Use a timeout generous enough that even a saturated CI runner fires it
+    // well before the poll deadline, without becoming so long that the test
+    // contributes meaningfully to suite wall-time.
+    const timeoutSignal = AbortSignal.timeout(50);
     const ctrl = new AbortController();
     const merged = AbortSignal.any([timeoutSignal, ctrl.signal]);
-    await new Promise((r) => setTimeout(r, 20));
+    // Poll until the merged signal is aborted rather than relying on a fixed
+    // sleep that can race the event loop under heavy PBT load.
+    const deadline = Date.now() + 500;
+    while (!merged.aborted && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
     expect(merged.aborted).toBe(true);
     expect(classifyAbortCause(merged, makeAbortError())).toBe("timeout");
   });


### PR DESCRIPTION
## Why

The **Property tests (nightly)** workflow [failed on 2026-05-26](https://github.com/purrgrammer/fragua/actions/runs/26441934168) (all 5 shards). This was the **first nightly to actually exercise the heavy daemon executor-fault PBT suite** — prior "successes" ran only 825 tests in ~6.5s (they predated that suite landing on `main`); the failing run ran 1064 tests in 221s.

Two distinct problems, both confined to test/CI config — **no product code changes**:

### 1. Legitimate 5000ms timeouts (the primary failure, ~7 tests)

The heavy properties scale `numRuns` via `pbtRuns()` by `FRAGUA_PBT_RUNS`, so at 20× a single property runs e.g. `pbtRuns(150)=3000` driven `runOne` harness invocations and legitimately takes >5s — hitting Bun's **default 5000ms per-test timeout**. Reproduced locally: `executor-faults.property.test.ts` (OCC-at-commit-seam ×2, handler-hang-leaked) plus the restart/resume/transcript PBT tests all fail with `timed out after 500Xms`.

**Fix:** add `--timeout 120000` to the nightly's `bun test` command only (the job already has `timeout-minutes: 30`). Per-PR CI and the `pbtRuns()` baselines are untouched.

### 2. Timer-fragile flakes (~5 tests, CI-only — pass locally)

Tests using tiny real wall-clock timers / short real-time windows slip when the 20× CPU-bound PBT phase starves the event loop in the same process:

- `blob-gc.test.ts` "sweep that throws": poll until ≥2 sweeps within a 2s ceiling instead of a fixed 40ms window.
- `executor.timeout.test.ts` `classifyAbortCause` real-timer race: `AbortSignal.timeout(5)`→`(50)` and poll-until-aborted instead of a fixed 20ms sleep.

Assertions are unchanged — only the timing margins widen. The watchdog tests (`maxMs` 10/20) are left alone: they drive deterministic `runOne` with `leakGraceMs: 500`, no real-timer assertion.

## Verification

- Both touched test files pass at `FRAGUA_PBT_RUNS=20` (18 tests).
- `bun run ci` (lint + typecheck + tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)