### PR TITLE
[release] 0.2.0 — CI bundles, portable .fragua, unattended PR review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,10 +11,10 @@ name: PR review
 # bot verdict that could safely gate a merge; CI remains the hard required gate.)
 #
 # The review runs fragua FROM SOURCE (not setup-fragua's released binary) so it
-# exercises the code under review — and `fragua ci --export`, which lands the run
-# as a secret-free `.fragua` bundle (the flag is newer than any release). The
-# trust boundary is unchanged: a same-repo PR already controls pr_review.yaml and
-# this file, and fork PRs (no secrets) are skipped.
+# exercises the code under review — including `fragua ci --export`, which lands
+# the run as a secret-free `.fragua` bundle. The trust boundary is unchanged: a
+# same-repo PR already controls pr_review.yaml and this file, and fork PRs (no
+# secrets) are skipped.
 
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Notes come from the matching CHANGELOG.md section (e.g. tag v0.2.0 →
+      # the `## [0.2.0]` block), not auto-generated commit lists — the curated
+      # entry is the release note. Fall back to --generate-notes if the version
+      # has no section yet, so a tag never fails to publish on a missing block.
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v v="$version" '
+            $0 ~ "^## \\[" v "\\]" { inblock = 1; next }
+            inblock && /^## \[/    { exit }
+            inblock                { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            notes=(--notes-file release-notes.md)
+          else
+            notes=(--generate-notes)
+          fi
           gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 \
             || gh release create "$GITHUB_REF_NAME" \
-                 --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
+                 --title "$GITHUB_REF_NAME" "${notes[@]}" --verify-tag
 
   binaries:
     needs: create-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to fragua are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions are
+[SemVer](https://semver.org/). Pre-1.0: minor versions may carry breaking
+changes, and anything marked **experimental** can change shape without a compat
+guarantee.
+
+## [0.2.0] — 2026-05-27
+
+This release marks the start of running fragua **on CI** and pulling the run
+back down as a portable `.fragua` bundle for local inspection and aggregation.
+
+### Added
+
+- **Portable `.fragua` bundles (experimental).** A bundle is a first-class
+  container: one or more runs (as their raw event logs), the workflows they
+  reference, and the content-addressed blobs they produced. A run's truth is its
+  event log — `run_state` is a projection and is **not** bundled; it is
+  re-derived by replaying events on import. Three verbs:
+  - `fragua ci --export <file.fragua>` — write a bundle for the run just executed.
+  - `fragua show <file.fragua>` — validate + summarize a bundle, no store needed.
+  - `fragua import <file.fragua>` — merge a bundle into a store, deriving
+    `run_state`. Imported runs are inert by construction (won't be dispatched).
+
+  Bundles are secret-free by construction (they never carry
+  `provider_credentials` / `provider_config`). The format is **experimental** and
+  release-gated: `bundleVersion` bumps freely with no migration path while
+  unstable — treat a bundle as a throwaway inspection artifact, not durable
+  storage. See [`docs/proposals/bundles.md`](docs/proposals/bundles.md).
+- **Genesis identity in the event log.** `intent.run_enqueued` now carries the
+  whole run identity (project, workflow link, routing seed, contract version), so
+  a complete `run_state` is derivable by replaying a run's events — the keystone
+  that makes derive-on-import possible.
+- **Unattended PR review on GitHub.** The `pr_review` workflow + `pr-review.yml`
+  run a multi-step review (`scope → review → verify → verdict → post`) over a
+  PR's diff with `fragua ci`, posting the result back as a `comment` or
+  `request-changes` review. The verdict is a routing LLM node that classifies
+  `comment` / `changes`. Read-only over the untrusted diff; fork PRs are skipped;
+  no auto-merge (a `GITHUB_TOKEN` bot cannot post an APPROVED state, and CI
+  remains the hard required gate). The job self-tests `fragua ci --export` and
+  uploads the resulting bundle, failing closed if a provider key appears in the
+  bytes.
+
+### Changed
+
+- `fragua ci` prunes its `--db` artifact to the portable tables only (no
+  credentials), so the embedded-executor store is shareable.
+- `non_retryable` is now a retry-policy hint rather than a goal-gate gate
+  ([core, agent]).
+
+### Fixed
+
+- Nightly property-test suite: raised the per-test timeout to fit PBT scaling and
+  deflaked timer-fragile tests (#4).
+
+[0.2.0]: https://github.com/purrgrammer/fragua/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/purrgrammer/fragua/releases/tag/v0.1.0

--- a/docs/proposals/bundles.md
+++ b/docs/proposals/bundles.md
@@ -18,7 +18,7 @@ supersedes: "db-import.md §3 (tree-state/git-bundle), §3.2 (--rehydrate), §4.
 > experimental. Treat a bundle as a throwaway inspection artifact, not durable
 > storage. Do not wire production CI to depend on the format yet.
 
-> **Status: implemented** on branch `run-bundle-import` — genesis enrichment (§2),
+> **Status: shipped** on `main` in 0.2.0 (#3, #5) — genesis enrichment (§2),
 > the bundle format (§3), `ci --export` / `show` / `import` (§4), derive-on-import
 > (run_state is replayed, not carried), inline messages (§5 v1), and the removal
 > of the tree-state / `--rehydrate` / `adopt` surface (§8). Deferred as written:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragua",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "a local dark software forge",
   "type": "module",


### PR DESCRIPTION
Cuts the **0.2.0** release.

## Changes
- **`package.json`** → version `0.2.0`
- **`CHANGELOG.md`** (new) — 0.2.0 line: portable `.fragua` bundles (export/show/import, derive `run_state` on import), genesis identity in the event log, unattended PR review on GitHub.
- **`docs/proposals/bundles.md`** — status flipped to *shipped on main in 0.2.0*.
- **`.github/workflows/pr-review.yml`** — comment cleanup (the `--export` flag is no longer "newer than any release").
- **`.github/workflows/release.yml`** — publish the matching `CHANGELOG.md` section as the release notes (awk-extract the `## [<version>]` block keyed off the tag), falling back to `--generate-notes` when a version has no section.

## Release flow
Merge to `main`, then `git tag v0.2.0 && git push origin v0.2.0` to fire the binary matrix + publish the release with the curated notes.

## Validation
`bun run ci` green locally — 2400 pass, 1 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)