### PR TITLE
[ci] pr-review: run released fragua (setup-fragua@v0.2.0) instead of from source

### DIFF
--- a/.github/actions/setup-fragua/README.md
+++ b/.github/actions/setup-fragua/README.md
@@ -9,7 +9,7 @@ the same way a test suite does.
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.1.0
+  - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.2.0
   - run: fragua ci my-workflow
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -24,7 +24,7 @@ resolves against `.fragua/workflows/<name>.yaml` in the checkout (and
 
 | Input | Default | Description |
 |---|---|---|
-| `version` | `latest` | Release tag to install (e.g. `v0.1.0`), or `latest` for the newest release. Pin it for reproducible CI. |
+| `version` | `latest` | Release tag to install (e.g. `v0.2.0`), or `latest` for the newest release. Pin it for reproducible CI. |
 | `web` | `false` | `false` installs the smaller **headless** binary (no `harness`/`serve` UI — fine for `fragua ci`). `true` installs the full binary with the web UI. |
 | `token` | `${{ github.token }}` | Token used to download the release asset. The default works when the consumer repo can read the fragua repo's releases. |
 
@@ -104,7 +104,7 @@ fragua import run.fragua                   # merge into a store (default: the ha
 fragua runs status|events|messages <run-id>
 ```
 
-> `--export` is available from the fragua release that ships it. On an older
+> `--export` ships in fragua **0.2.0** and later. On an older
 > binary, `--db <path>` pins the raw store — but it can carry secrets (a tool that
 > echoes a key into an event lands in it), so scrub the provider tables and verify
 > before uploading. Prefer the bundle: it's secret-free by construction.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: PR review
 
-# Unattended review on every push to a PR: builds fragua from THIS PR's checkout
-# (bun) and runs the `pr_review` workflow (`.fragua/workflows/pr_review.yaml`)
+# Unattended review on every push to a PR: installs the released fragua binary
+# (setup-fragua) and runs the `pr_review` workflow (`.fragua/workflows/pr_review.yaml`)
 # with `fragua ci`, posting the result back to the PR as a `comment` or
 # `request-changes` review. Read-only: it runs LLM tool-calls over an untrusted
 # diff, so it must NOT hold `contents: write` (prompt-injection surface).
@@ -10,11 +10,13 @@ name: PR review
 # using GITHUB_TOKEN cannot post an APPROVED review state anyway, so there is no
 # bot verdict that could safely gate a merge; CI remains the hard required gate.)
 #
-# The review runs fragua FROM SOURCE (not setup-fragua's released binary) so it
-# exercises the code under review — including `fragua ci --export`, which lands
-# the run as a secret-free `.fragua` bundle. The trust boundary is unchanged: a
-# same-repo PR already controls pr_review.yaml and this file, and fork PRs (no
-# secrets) are skipped.
+# The review pins a released fragua (setup-fragua@<tag>) for a reproducible
+# review engine; `fragua ci --export` (shipped in 0.2.0) lands the run as a
+# secret-free `.fragua` bundle. The engine is pinned, but the binary still reads
+# THIS PR's `.fragua/workflows/pr_review.yaml` from the checkout, so workflow
+# changes are still exercised. The trust boundary is unchanged: a same-repo PR
+# already controls pr_review.yaml and this file, and fork PRs (no secrets) are
+# skipped.
 
 on:
   pull_request:
@@ -44,16 +46,10 @@ jobs:
         with:
           fetch-depth: 0 # full history so the review can diff against base
 
-      # Build fragua from the PR's checkout (not setup-fragua's released binary)
-      # so the review runs the code under review AND `fragua ci --export`. Mirror
-      # ci.yml's bun setup.
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2.17"
-      - run: bun install --frozen-lockfile
+      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.2.0
 
       - name: "Review PR #${{ github.event.pull_request.number }}"
-        run: bun run fragua ci pr_review --input pr=${{ github.event.pull_request.number }} --export "$RUNNER_TEMP/pr-review.fragua"
+        run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }} --export "$RUNNER_TEMP/pr-review.fragua"
         env:
           # Swap for ANTHROPIC_OAUTH_TOKEN to draw on a Claude subscription
           # instead of API billing (setup-fragua/README.md § Credentials).


### PR DESCRIPTION
Follow-up to the 0.2.0 release (#6, tag `v0.2.0`).

Now that `fragua ci --export` ships in **0.2.0**, the PR-review workflow no longer needs to build fragua from source to reach the bundle-export flag.

## Changes
- **`.github/workflows/pr-review.yml`** — replace the `setup-bun` + `bun install` + `bun run fragua …` steps with `setup-fragua@v0.2.0` + `fragua ci …`. Pins a reproducible review engine and drops the build step (faster). Header comment rewritten to match.
- **`.github/actions/setup-fragua/README.md`** — bump example pins `@v0.1.0` → `@v0.2.0`; note `--export` ships in 0.2.0+.

## Tradeoff (intentional)
The review engine is now **pinned to a release**, not built from the PR. The binary still reads *this PR's* `.fragua/workflows/pr_review.yaml` from the checkout, so **workflow changes are still exercised** — but a PR that changes the fragua *engine* is reviewed by v0.2.0, not its own code. `ci.yml` still builds + tests from source, so the engine is not unguarded.

## Self-validation
This PR's own review run exercises the new `setup-fragua@v0.2.0` path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)