### PR TITLE
[store] exclude bare-cwd runs from the inbox queries

### DIFF
--- a/packages/store/src/run-state-queries.ts
+++ b/packages/store/src/run-state-queries.ts
@@ -19,6 +19,20 @@ import type { Database } from "bun:sqlite";
 import type { InboxStatus, RunStatus } from "@fragua/types";
 
 // ─────────────────────────────────────────────────────────────────────
+// Shared SQL fragments
+// ─────────────────────────────────────────────────────────────────────
+
+/** A run is actionable in the inbox — acceptable or discardable — only if it
+ *  has a local worktree, i.e. a non-null `cwd`. This is the negation of the
+ *  accept/discard gate (`checkGate` in `@fragua/workspace` refuses `cwd == null`
+ *  with `no_worktree`), so the inbox surfaces exactly what those verbs permit.
+ *  Imported runs are inert (`cwd` is null) yet re-derive `inbox_status='pending'`
+ *  from their folded log; without this they'd appear READY TO LAND but refuse
+ *  both accept and discard. Reused by every inbox-scoped query, qualified with
+ *  the caller's table alias. */
+const LANDABLE_HERE = "cwd IS NOT NULL";
+
+// ─────────────────────────────────────────────────────────────────────
 // Row types
 // ─────────────────────────────────────────────────────────────────────
 
@@ -238,6 +252,7 @@ export function selectRunSummaryRows(db: Database, opts: ListRunSummaryRowsOpts 
   if (inbox !== undefined) {
     clauses.push("r.inbox_status = ?");
     args.push(inbox);
+    clauses.push(`r.${LANDABLE_HERE}`);
   }
 
   const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
@@ -403,6 +418,7 @@ const SELECT_INBOX_ACTION_CANDIDATES_SQL = `
          rs.status           AS status
     FROM run_state rs
    WHERE rs.inbox_status IN ('pending', 'acted')
+     AND rs.${LANDABLE_HERE}
      AND EXISTS (
        SELECT 1 FROM events e
         WHERE e.run_id = rs.run_id
@@ -417,7 +433,9 @@ const SELECT_INBOX_ACTION_CANDIDATES_SQL = `
  *  operator-action intent (branch / commit / merge / discard). Scoped by
  *  the `inbox_status` partial index + an EXISTS over the run's events so the
  *  daemon sweep never walks every terminal run — only those an operator
- *  acted on. Mirrors `selectWakeCandidates`' OCC-ready row shape. */
+ *  acted on. The `LANDABLE_HERE` guard excludes inert imported runs (the gate
+ *  refuses their accept/discard before any intent is written, so this is
+ *  defensive). Mirrors `selectWakeCandidates`' OCC-ready row shape. */
 export function selectInboxActionCandidates(db: Database): WakeCandidateRow[] {
   return db.query<WakeCandidateRow, []>(SELECT_INBOX_ACTION_CANDIDATES_SQL).all();
 }

--- a/packages/store/test/inbox-landable.test.ts
+++ b/packages/store/test/inbox-landable.test.ts
@@ -1,0 +1,67 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { insertEventWeb } from "../src/event-queries.ts";
+import { migrate } from "../src/migrations.ts";
+import { insertRunState, selectInboxActionCandidates, selectRunSummaryRows } from "../src/run-state-queries.ts";
+
+// A run is in the inbox only if it can be landed *here* — accept/discard both
+// gate on a non-null `cwd` (`checkGate` → `no_worktree`). Imported runs are
+// inert (`cwd` null) yet re-derive `inbox_status='pending'` from their folded
+// log, so the inbox queries must drop them or they'd show READY TO LAND while
+// refusing both verbs. Same `cwd IS NOT NULL` predicate, both inbox queries.
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  migrate(db);
+  db.query(
+    "INSERT INTO workflows (sha, name, source, ir, ir_version, created_at) VALUES ('wf', 't', 's', '{}', 1, 0)",
+  ).run();
+  return db;
+}
+
+function seedTerminalInboxRun(db: Database, runId: string, cwd: string | null): void {
+  insertRunState(db, {
+    runId,
+    workflowSha: "wf",
+    contractVersion: 1,
+    routing: "{}",
+    metrics: "{}",
+    priority: 0,
+    enqueuedAt: 1,
+    readyAt: 1,
+    updatedAt: 1,
+    cwd,
+    projectId: "p",
+    projectName: "p",
+    workflowName: "wf",
+    workflowScope: "local",
+    workflowPath: null,
+    scheduleId: null,
+  });
+  db.query("UPDATE run_state SET status='completed', inbox_status='pending' WHERE run_id=?").run(runId);
+}
+
+describe("inbox queries — landable-here gate (cwd IS NOT NULL)", () => {
+  test("selectRunSummaryRows({inbox:'pending'}) excludes bare-cwd (imported) runs", () => {
+    const db = freshDb();
+    seedTerminalInboxRun(db, "local", "/repos/alpha");
+    seedTerminalInboxRun(db, "imported", null);
+
+    const rows = selectRunSummaryRows(db, { inbox: "pending" });
+
+    expect(rows.map((r) => r.runId)).toEqual(["local"]);
+  });
+
+  test("selectInboxActionCandidates excludes bare-cwd runs even with an unapplied accept intent", () => {
+    const db = freshDb();
+    seedTerminalInboxRun(db, "local", "/repos/alpha");
+    seedTerminalInboxRun(db, "imported", null);
+    // last_applied_seq is 0; an intent at seq 1 is unapplied for both runs.
+    insertEventWeb(db, "local", 1, "intent.accept_run", "{}", 2);
+    insertEventWeb(db, "imported", 1, "intent.discard_run", "{}", 2);
+
+    const candidates = selectInboxActionCandidates(db);
+
+    expect(candidates.map((c) => c.runId)).toEqual(["local"]);
+  });
+});


### PR DESCRIPTION
## Problem

Imported runs are inert — their derived `cwd` is `null` so the daemon never picks them up. But `run_state` is re-derived on import by folding the event log, and a run whose log contains a `fact.snapshot_recorded` re-derives `inbox_status='pending'`. So an imported run surfaces under **READY TO LAND** in `fragua runs inbox` / the web inbox, yet both `accept` and `discard` refuse it:

```
packages/workspace/src/run-actions.ts — checkGate
  if (gate.cwd == null) return { ok: false, reason: "no_worktree", … };
```

→ a stuck inbox entry that can be neither landed nor discarded.

## Fix

`cwd` is a local binding, not part of the event fold, so the reducer computing `inbox_status='pending'` is correct in the abstract — the run *did* produce recoverable work, it's just not landable in *this* store. The read layer is the right seam.

Add a shared predicate `LANDABLE_HERE = "cwd IS NOT NULL"` (the negation of the accept/discard gate) and reuse it in both inbox-scoped queries:
- `selectRunSummaryRows` — applied when the `inbox` filter is set (the inbox view)
- `selectInboxActionCandidates` — the daemon wake-pending sweeper (defensive; the gate already blocks the intent for bare-cwd runs)

`selectGcEligibleSnapshotRuns` is unaffected — it already scopes by `cwd = ?`.

## Test

`packages/store/test/inbox-landable.test.ts` (query-level, `:memory:`): a `cwd=null` + `inbox_status='pending'` row is excluded from both queries; the `cwd`-set sibling is kept.

- `@fragua/store` typecheck clean
- store suite: 177 pass / 0 fail (+2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)