### PR TITLE
tool nodes: injection-safe `exec:` argv form

### DIFF
--- a/.agents/skills/workflows/SKILL.md
+++ b/.agents/skills/workflows/SKILL.md
@@ -93,7 +93,7 @@ steps:
 
 ## 3. Inputs — structured, typed, validated
 
-Workflows take **typed inputs**, declared in `inputs:` and referenced as `${{ inputs.name }}` in any `prompt:`, `text:`, or tool `run:` string. This is the *only* substitution token — there is no free-form `$ARGUMENTS`; everything a run needs is a declared input.
+Workflows take **typed inputs**, declared in `inputs:` and referenced as `${{ inputs.name }}` in any `prompt:`, `text:`, `run:`, or `exec:` string. This is the *only* substitution token — there is no free-form `$ARGUMENTS`; everything a run needs is a declared input.
 
 ```yaml
 inputs:
@@ -244,6 +244,10 @@ Three tools are **force-included** and need not be listed — they're available 
 
 ### Tool steps
 
+Tool steps have two execution forms, mutually exclusive (E033 / E034):
+
+**`run:` — shell string** (pipes, redirects, globs, multi-statement):
+
 ```yaml
 ci:
   type: tool
@@ -251,7 +255,26 @@ ci:
   max-retries: 5
 ```
 
-Side-effect-only: exit 0 → `success`, non-zero → `fail`. The exit code is the entire result — **tool steps don't feed data forward**. stdout/stderr are kept as artifacts for debugging. If you need to run a script *and reason about its output*, call it from inside an `llm` step's `bash` tool instead (E008 rejects an empty `run`).
+`${{ inputs.* }}` values are POSIX-single-quote-escaped before the command is passed to `sh -c`.
+
+**`exec:` — argv vector** (injection-safe form for dynamic arguments):
+
+```yaml
+format:
+  type: tool
+  exec:
+    cmd: jq
+    args:
+      - .name
+      - ${{ inputs.file }}
+  next: done
+```
+
+`${{ inputs.* }}` is substituted **per element** — `cmd` and each `args[i]` independently — and the substituted value becomes exactly one argv token, never re-split. A value containing spaces, newlines, `$()`, or backticks is inert data; no shell sees it. Use `exec:` whenever a step interpolates user-provided or generated values, to prevent injection.
+
+Blocklist rules apply to both forms. Additionally, `exec.cmd` may not be a shell interpreter (`sh`, `bash`, `zsh`, `dash`, `fish`) — static reject (E034) for literal names, runtime reject for interpolated ones. This ensures all shell execution passes through the `run:` blocklist-scanned path.
+
+Side-effect-only: exit 0 → `success`, non-zero → `fail`. The exit code is the entire result — **tool steps don't feed data forward**. stdout/stderr are kept as artifacts for debugging. If you need to run a script *and reason about its output*, call it from inside an `llm` step's `bash` tool instead.
 
 ---
 

--- a/.agents/skills/workflows/references/validator-codes.md
+++ b/.agents/skills/workflows/references/validator-codes.md
@@ -28,9 +28,11 @@ Errors fail validation; warnings are strong hints. Source of truth: `packages/co
 | E027 | `summary: low\|medium\|high` set on a step without a `thread` — summarising nothing has no effect. |
 | E028 | Step id `exit` is reserved for the graceful sink — target it (`next: exit` / `on: {fail: exit}`), don't declare a regular step named `exit`. |
 | E029 | Step id `start` is reserved for the synthesized entry node — rename the step. |
-| E030 | `${{ inputs.x }}` references an input not declared in the workflow's `inputs:` block (scans `prompt` / `text` / `run`). Add it to `inputs:` or fix the typo. |
+| E030 | `${{ inputs.x }}` references an input not declared in the workflow's `inputs:` block (scans `prompt` / `text` / `run` / `exec.cmd` / `exec.args[*]`). Add it to `inputs:` or fix the typo. |
 | E031 | A goal-gate step (uses `retry:`) has no `max-retries:` — the per-gate retarget cap is required on every `retry:` gate. Add `max-retries: N` to the gate step. |
 | E032 | A step declares no success successor. Flow is explicit — there is no linear fall-through to the next declared step. Add `next:` / `on: {success: …}` / `routes:`, or `next: exit` to finish a branch. |
+| E033 | A `tool` step sets both `run:` and `exec:` — they are mutually exclusive. Remove one. |
+| E034 | A `tool` step has neither `run:` nor `exec:` (the executor has nothing to spawn), **or** `exec.cmd` is a literal shell interpreter (`sh`, `bash`, `zsh`, `dash`, `fish`). Shell interpreters are refused on the exec path to prevent bypassing the `run:` blocklist scan. |
 
 ## Warnings
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -70,8 +70,15 @@ A workflow is a YAML document with `name:` and a `steps:` map at the root (GitHu
 |---|---|
 | `llm` | LLM call (the implicit default when `type:` is omitted) |
 | `human` | operator-gated routing |
-| `tool` | graph-level shell step (`run:`) |
+| `tool` | graph-level side-effect step (`run:` shell string **or** `exec:` argv vector) |
 | `exit` | reserved graceful-halt sink |
+
+**Tool steps — `run:` vs `exec:`.**  Tool steps are side-effect-only: exit 0 → `outcome=success`, non-zero → `outcome=fail`. Two mutually-exclusive execution forms are supported (validator E033 / E034):
+
+- `run: <shell-string>` — passed verbatim to `sh -c`. The right choice for shell idioms (pipes, redirects, globs, multi-statement commands). `${{ inputs.* }}` values are POSIX-single-quote-escaped before substitution.
+- `exec: {cmd: <binary>, args: [<arg>, …]}` — invokes the binary directly with no shell. `${{ inputs.* }}` is substituted **per element** (`cmd` and each `args[i]` independently); the substituted value becomes exactly one argv token and is never re-split. A value containing spaces, newlines, `$()`, or backticks is inert data at the child process — no shell sees it. This is the injection-safe form for steps that interpolate dynamic or generated values. See `docs/proposals/tool-exec-variant.md` for the full decision record.
+
+For the `exec:` path: the resolved `cmd` is checked against the blocklist AND refused when it is a shell interpreter (`sh`, `bash`, `zsh`, `dash`, `fish`). The latter check is static (validator E034) for literal `cmd` values and runtime for interpolated ones. This preserves the invariant that all shell execution passes through the `run:` path.
 
 `start` is synthesized by the parser (the entry node pointing at the first declared step) and is never authored; `exit` is the reserved sink. Declaring a step named `start` or `exit` with a mismatched type is rejected (`E029` / `E028`).
 
@@ -211,7 +218,7 @@ The gate's `max_retries` bounds the chain so a perpetually-failing `retry_target
 
 ### 3.8 Substitution
 
-One token family expands in `prompt:`, `text:`, and `run:` strings before the handler sees them:
+One token family expands in `prompt:`, `text:`, `run:`, and `exec:` strings before the handler sees them:
 
 | Token | Meaning |
 |---|---|
@@ -221,7 +228,7 @@ The run's free-form positional (CLI trailing args, or `POST /runs` `input`) land
 
 Cross-node data transfer happens through **shared threads** (§3.3), not through prompt substitution. Two llm steps with the same `thread:` share the LLM conversation — downstream nodes see upstream replies as regular assistant messages in their context. A receiving node may set `summary=low|medium|high` to see a summariser-compressed view of the prior thread instead of the raw history. When the producer doesn't share a thread with the consumer (rare; usually a sign to redesign), the consumer re-derives the data inside its own turn via the `bash` / `read` tools.
 
-Tool nodes (`type: tool`, §3.1) are side-effect-only: exit 0 → `outcome=success`, non-zero → `outcome=fail`. They do not feed data forward. Workflows that need to run a deterministic script and reason about its output should call the script from inside an llm step's `bash` tool instead of synthesising a tool-node-then-llm chain.
+Tool nodes (`type: tool`, §3.1) are side-effect-only: exit 0 → `outcome=success`, non-zero → `outcome=fail`. For the `exec:` variant, substitution is per-element with no re-split (see §3.1). They do not feed data forward. Workflows that need to run a deterministic script and reason about its output should call the script from inside an llm step's `bash` tool instead of synthesising a tool-node-then-llm chain.
 
 ### 3.9 Budgets
 

--- a/docs/proposals/tool-exec-variant.md
+++ b/docs/proposals/tool-exec-variant.md
@@ -1,12 +1,17 @@
 ---
 title: Tool exec variant — injection-safe argv execution, with an idempotency marker
 summary: "The `tool` node executes only one way: `run:` → `sh -c <substituted string>`. Interpolating a value into that string is a shell-injection + tokenization hazard (the handler already carries a mitigation comment), it is non-reproducible (per-machine `/bin/sh` variance), and it mangles exit codes through the shell layer. Add a second, mutually-exclusive form — `exec: {cmd, args}` — that spawns argv directly with NO shell and substitutes per-element (a value becomes exactly one inert argv token, never re-parsed). This is the correct default for any step consuming generated/untrusted content — evals above all. Companion (independently shippable): an `idempotent:` marker that lets crash-recovery auto-re-run a tool instead of quarantining it. Both are additive over the source-hashed IR — zero freeze coupling; if workflow-ir (B) lands later they are clean `ir_version` bumps."
-status: proposed
+status: shipped
 maturity: designed
-last-reviewed: 2026-05-25
+last-reviewed: 2026-05-27
 ---
 
 # Tool exec variant
+
+> **Status: the `exec:` form shipped.** `tool` nodes now accept `exec: {cmd,
+> args}` with per-element substitution, no shell, and blocklist +
+> shell-interpreter refusal on `cmd` (validator E033/E034). The `idempotent:`
+> marker (§4) is the remaining deferred follow-up.
 
 > Sibling of [`structured-outputs.md`](structured-outputs.md) (it makes
 > `${{ steps.X.outputs.f }}` interpolation safe) and

--- a/packages/agent/test/system-prompt-env.test.ts
+++ b/packages/agent/test/system-prompt-env.test.ts
@@ -47,6 +47,7 @@ describe("renderRunEnvironment after RunEnvironment.cwd rename", () => {
       listDir: async () => [],
       glob: async () => [],
       exec: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
+      spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     };
     const out = deriveRunEnv(fakeWorktree, "fallback-run-id");
     expect(out.cwd).toBe("/wt/abc");

--- a/packages/core/src/engine/substitution.ts
+++ b/packages/core/src/engine/substitution.ts
@@ -39,6 +39,30 @@ export function substitute(template: string, opts: SubstitutionOptions = {}): st
   return template.replace(INPUT_REF_RE, (_whole, name: string) => fmt(inputs[name] ?? ""));
 }
 
+/** Substitute `${{ inputs.* }}` tokens in an argv vector, per-element.
+ *
+ * Each element (cmd and every args[i]) is substituted independently;
+ * the resolved value becomes exactly one argv token and is NEVER
+ * re-split on whitespace or shell-parsed. This is the injection-safety
+ * contract for the `exec:` tool-node form: metacharacters in input
+ * values (`$()`, backticks, spaces, newlines, quotes) are inert data
+ * at the child process boundary because no shell ever sees them.
+ *
+ * No shell-quoting is applied — the unescaped value goes straight into
+ * the argv vector passed to `child_process.spawn`. */
+export function substituteArgv(
+  parts: { cmd: string; args: string[] },
+  opts: { args?: SubstitutionArgs } = {},
+): { cmd: string; args: string[] } {
+  const inputs = opts.args?.inputs ?? {};
+  const replaceToken = (token: string): string =>
+    token.replace(INPUT_REF_RE, (_whole, name: string) => inputs[name] ?? "");
+  return {
+    cmd: replaceToken(parts.cmd),
+    args: parts.args.map(replaceToken),
+  };
+}
+
 /** Every `${{ inputs.X }}` reference name in a template. Used by the
  * validator (E030) to flag references to undeclared inputs. */
 export function inputReferences(template: string): string[] {

--- a/packages/core/src/engine/validator.ts
+++ b/packages/core/src/engine/validator.ts
@@ -1,9 +1,27 @@
 // Graph linter. Catches structural and semantic issues before execution.
 // See docs/SPEC.md §4.1 (validation phase).
 
+import { basename } from "node:path";
 import type { Edge, Graph } from "../types/graph.ts";
 import { isRetryPresetName, RETRY_PRESETS } from "./retry-policy.ts";
 import { inputReferences } from "./substitution.ts";
+
+/** Shell interpreters refused as `exec.cmd` (static check for literal values). */
+const SHELL_INTERPRETERS: ReadonlySet<string> = new Set(["sh", "bash", "zsh", "dash", "fish"]);
+
+/** True when a string is (or resolves to) a shell interpreter basename.
+ * Case-insensitive; strips `.exe` suffix. */
+function isShellInterpreterLiteral(cmd: string): boolean {
+  let name = basename(cmd).toLowerCase();
+  if (name.endsWith(".exe")) name = name.slice(0, -4);
+  return SHELL_INTERPRETERS.has(name);
+}
+
+/** True when a string contains `${{ inputs.* }}` — meaning it is interpolated
+ * and cannot be statically resolved at validate-time. */
+function isInterpolated(s: string): boolean {
+  return /\$\{\{\s*inputs\.[a-zA-Z][a-zA-Z0-9_-]*\s*\}\}/.test(s);
+}
 
 /** Whitelist of known node attribute names — the IR (snake_case) field set
  * the validator runs against, *after* the parser has lowered authoring keys
@@ -32,6 +50,7 @@ const KNOWN_NODE_ATTRS: ReadonlySet<string> = new Set([
   "retry_target",
   "fallback_retry_target",
   "tool_command",
+  "tool_argv",
   "max_cost_usd",
   "max_tokens",
   "skills",
@@ -269,11 +288,15 @@ export function validate(graph: Graph, opts: ValidateOptions = {}): Diagnostic[]
   // workflow's `inputs:` block. Substitution would silently collapse the
   // placeholder to "" at runtime, so catch the typo / missing declaration
   // at validate-time. Scans the substituted-string attrs (prompt / text /
-  // tool_command) on every node.
+  // tool_command / tool_argv.cmd / tool_argv.args[*]) on every node.
   {
     const declared = new Set((graph.attrs.inputs ?? []).map((d) => d.name));
     for (const n of nodes) {
-      const fields = [n.attrs.prompt, n.attrs.text, n.attrs.tool_command];
+      const fields: (string | undefined)[] = [n.attrs.prompt, n.attrs.text, n.attrs.tool_command];
+      if (n.attrs.tool_argv !== undefined) {
+        fields.push(n.attrs.tool_argv.cmd);
+        for (const arg of n.attrs.tool_argv.args) fields.push(arg);
+      }
       const seen = new Set<string>();
       for (const f of fields) {
         if (typeof f !== "string") continue;
@@ -311,19 +334,54 @@ export function validate(graph: Graph, opts: ValidateOptions = {}): Diagnostic[]
     }
   }
 
-  // E008: tool node (tool node) must carry a non-empty `tool_command`.
-  // Without it the executor has nothing to spawn and halts at dispatch.
+  // Tool node execution form checks.
+  //
+  // E033: both `run:` (tool_command) and `exec:` (tool_argv) set — mutually exclusive.
+  // E034: neither set (executor has nothing to spawn), OR `exec.cmd` is a literal
+  //       shell interpreter (sh/bash/zsh/dash/fish) which would bypass the run: path's
+  //       blocklist scan.
+  // E008: kept for backwards compat — fires the same as E034 (neither-set) so
+  //       existing tests relying on E008 continue to pass.
   for (const n of nodes) {
     if (n.type !== "tool") continue;
-    const cmd = n.attrs.tool_command;
-    if (typeof cmd !== "string" || cmd.trim().length === 0) {
+    const hasShell = typeof n.attrs.tool_command === "string" && n.attrs.tool_command.trim().length > 0;
+    const hasArgv = n.attrs.tool_argv !== undefined;
+
+    if (hasShell && hasArgv) {
       diags.push({
         severity: "error",
-        code: "E008",
-        message: `tool node "${n.id}" must define a non-empty \`tool_command\` attribute`,
+        code: "E033",
+        message: `tool node "${n.id}" sets both \`run:\` and \`exec:\` — they are mutually exclusive`,
         nodeId: n.id,
         ...(n.loc !== undefined ? { loc: n.loc } : {}),
       });
+    } else if (!hasShell && !hasArgv) {
+      // E034 for the "neither" case; also emit E008 for backwards compat.
+      diags.push({
+        severity: "error",
+        code: "E008",
+        message: `tool node "${n.id}" must define either \`run:\` or \`exec:\``,
+        nodeId: n.id,
+        ...(n.loc !== undefined ? { loc: n.loc } : {}),
+      });
+      diags.push({
+        severity: "error",
+        code: "E034",
+        message: `tool node "${n.id}" must define either \`run:\` or \`exec:\``,
+        nodeId: n.id,
+        ...(n.loc !== undefined ? { loc: n.loc } : {}),
+      });
+    } else if (hasArgv && n.attrs.tool_argv !== undefined) {
+      const argv = n.attrs.tool_argv;
+      if (!isInterpolated(argv.cmd) && isShellInterpreterLiteral(argv.cmd)) {
+        diags.push({
+          severity: "error",
+          code: "E034",
+          message: `tool node "${n.id}" exec.cmd is a shell interpreter ("${argv.cmd}") — all shell execution must go through \`run:\` so the blocklist scan applies`,
+          nodeId: n.id,
+          ...(n.loc !== undefined ? { loc: n.loc } : {}),
+        });
+      }
     }
   }
 

--- a/packages/core/src/handler/handlers/tool.ts
+++ b/packages/core/src/handler/handlers/tool.ts
@@ -37,22 +37,28 @@
 //     quarantine a run whose daemon crashed mid-spawn.
 
 import type { ToolNodeMessage } from "@fragua/types";
-import { substitute } from "../../engine/substitution.ts";
+import { substitute, substituteArgv } from "../../engine/substitution.ts";
 import type { ExecutionEnvironment } from "../../types/execution.ts";
 import type { Handler, HandlerResult, HandlerSpec } from "../types.ts";
 
 export interface ToolConfig {
-  /** Raw shell command; substituted at dispatch time. Required — an empty
-   * tool_command is a workflow authoring error. */
-  toolCommand: string;
+  /** Raw shell command; substituted at dispatch time. Mutually exclusive
+   * with `toolArgv`. An empty toolCommand is a workflow authoring error. */
+  toolCommand?: string;
+  /** argv-vector form (from `exec:` authoring). Mutually exclusive with
+   * `toolCommand`. Each element is substituted independently and passed
+   * as a single inert argv token to the child process (no shell). */
+  toolArgv?: { cmd: string; args: string[] };
   /** Next node on success (exit 0). When unset, defers to the executor's
    * edge selector (5-rule priority on unconditional outgoing edges). */
   nextNode?: string;
   /** Hard timeout. Defaults to 5 minutes — a shell step that needs more
    * should probably be broken up. */
   maxMs?: number;
-  /** Spawn function injection point for tests. Defaults to `runWithBun`. */
+  /** Spawn function injection point for tests (shell path). Defaults to `runWithBun`. */
   spawner?: SpawnFn;
+  /** Spawn function injection point for tests (argv/exec path). */
+  argvSpawner?: ArgvSpawnFn;
 }
 
 export interface ToolRunResult {
@@ -63,15 +69,22 @@ export interface ToolRunResult {
 }
 
 export type SpawnFn = (cmd: string, signal: AbortSignal) => Promise<ToolRunResult>;
+export type ArgvSpawnFn = (cmd: string, args: string[], signal: AbortSignal) => Promise<ToolRunResult>;
 
 const DEFAULT_MAX_MS = 5 * 60 * 1000;
 
 export function makeToolHandler(cfg: ToolConfig): HandlerSpec {
   const explicitSpawner = cfg.spawner;
+  const explicitArgvSpawner = cfg.argvSpawner;
   const maxMs = cfg.maxMs ?? DEFAULT_MAX_MS;
 
   const handler: Handler = async (ctx) => {
-    const rawCommand = cfg.toolCommand;
+    // Dispatch on exec: (argv) vs run: (shell) form.
+    if (cfg.toolArgv !== undefined) {
+      return runArgvForm(cfg.toolArgv, ctx, maxMs, explicitArgvSpawner);
+    }
+
+    const rawCommand = cfg.toolCommand ?? "";
     if (rawCommand.trim().length === 0) {
       return {
         kind: "halt",
@@ -217,6 +230,134 @@ export function makeToolHandler(cfg: ToolConfig): HandlerSpec {
     maxMs,
     handler,
   };
+}
+
+/** Handle the `exec:` (argv-vector) path. Substitutes inputs per-element,
+ * refuses shell interpreters as cmd, and routes through env.spawn(). */
+async function runArgvForm(
+  rawArgv: { cmd: string; args: string[] },
+  ctx: Parameters<Handler>[0],
+  maxMs: number,
+  argvSpawner: ArgvSpawnFn | undefined,
+): Promise<HandlerResult> {
+  const resolved = substituteArgv(rawArgv, { args: ctx.args });
+
+  // Runtime shell-interpreter refusal (mirrors the static validator E034
+  // for interpolated cmd values that couldn't be checked at validate-time).
+  if (isShellInterpreterName(resolved.cmd)) {
+    return {
+      kind: "halt",
+      reason: "error",
+      detail: `tool exec: cmd "${resolved.cmd}" is a shell interpreter — use \`run:\` for shell commands`,
+    } satisfies HandlerResult;
+  }
+
+  if (ctx.env === undefined && argvSpawner === undefined) {
+    return {
+      kind: "halt",
+      reason: "error",
+      detail:
+        "tool handler: no execution environment wired (this is a bug — every dispatch must carry ctx.env or cfg.argvSpawner)",
+    } satisfies HandlerResult;
+  }
+  const cwd = ctx.env?.cwd() ?? "";
+
+  let stdoutChunkIndex = 0;
+  let stderrChunkIndex = 0;
+  const onData = (chunk: string, kind: "stdout" | "stderr"): void => {
+    if (chunk.length === 0) return;
+    const SLICE_BYTES = 3 * 1024;
+    for (let i = 0; i < chunk.length; i += SLICE_BYTES) {
+      const piece = chunk.slice(i, i + SLICE_BYTES);
+      const idx = kind === "stdout" ? stdoutChunkIndex++ : stderrChunkIndex++;
+      ctx.emit("tool.output_chunk", { kind, delta: piece, content_index: idx });
+    }
+  };
+
+  // Display form of the command for artifacts/messages — join with spaces for
+  // readability; this is informational only, not re-parsed.
+  const commandDisplay = [resolved.cmd, ...resolved.args].join(" ");
+
+  let ranResult: ToolRunResult | undefined;
+  try {
+    ranResult = await ctx.externalCall(
+      { toolName: "tool.exec", args: { cmd: resolved.cmd, args: resolved.args, cwd }, attempt: ctx.iteration + 1 },
+      () => runArgv(resolved.cmd, resolved.args, ctx.signal, ctx.env, argvSpawner, maxMs, onData),
+    );
+  } catch (err) {
+    if (isAbortError(err)) {
+      return { kind: "halt", reason: "error", detail: "tool aborted" } satisfies HandlerResult;
+    }
+    return {
+      kind: "halt",
+      reason: "error",
+      detail: `tool exec spawn failed: ${errorMessage(err)}`,
+    } satisfies HandlerResult;
+  }
+
+  const stdoutArtifactKey = `${ctx.nodeId}:stdout`;
+  ctx.artifacts.put(stdoutArtifactKey, ranResult.stdout, "text/plain", { replace: true });
+  if (ranResult.stderr.length > 0) {
+    ctx.artifacts.put(`${ctx.nodeId}:stderr`, ranResult.stderr, "text/plain", { replace: true });
+  }
+
+  const stdoutTail = truncateTail(ranResult.stdout, INLINE_OUTPUT_BYTES);
+  const stderrTail = truncateTail(ranResult.stderr, INLINE_OUTPUT_BYTES);
+  const message: ToolNodeMessage = {
+    role: "tool_node",
+    command: commandDisplay,
+    cwd,
+    exitCode: ranResult.exitCode,
+    durationMs: ranResult.durationMs,
+    stdout: stdoutTail.text,
+    stderr: stderrTail.text,
+    ...(stdoutTail.truncated ? { stdoutTruncated: true } : {}),
+    ...(stderrTail.truncated ? { stderrTruncated: true } : {}),
+    outputArtifactKey: stdoutArtifactKey,
+    timestamp: Date.now(),
+  };
+  ctx.messages.append(message);
+
+  ctx.emit("tool.completed", {
+    command: commandDisplay,
+    cwd,
+    exitCode: ranResult.exitCode,
+    durationMs: ranResult.durationMs,
+    stdoutBytes: ranResult.stdout.length,
+    stderrBytes: ranResult.stderr.length,
+  });
+
+  const outcomeStatus: "success" | "fail" = ranResult.exitCode === 0 ? "success" : "fail";
+  return { kind: "transition", outcomeStatus, tokens: 0, costUsd: 0 } satisfies HandlerResult;
+}
+
+/** Basename-match shell interpreter check (runtime variant of the static validator E034). */
+function isShellInterpreterName(cmd: string): boolean {
+  const SHELLS = new Set(["sh", "bash", "zsh", "dash", "fish"]);
+  const name =
+    cmd
+      .split("/")
+      .at(-1)
+      ?.toLowerCase()
+      .replace(/\.exe$/, "") ?? "";
+  return SHELLS.has(name);
+}
+
+async function runArgv(
+  cmd: string,
+  args: string[],
+  signal: AbortSignal,
+  env: ExecutionEnvironment | undefined,
+  spawner: ArgvSpawnFn | undefined,
+  timeoutMs: number,
+  onData?: (chunk: string, kind: "stdout" | "stderr") => void,
+): Promise<ToolRunResult> {
+  if (spawner) return spawner(cmd, args, signal);
+  if (env) {
+    const r = await env.spawn(cmd, args, { signal, timeoutMs, ...(onData ? { onData } : {}) });
+    return { exitCode: r.exitCode, stdout: r.stdout, stderr: r.stderr, durationMs: r.durationMs };
+  }
+  throw new Error("tool handler: unreachable — env-less dispatch without argvSpawner should have halted earlier");
 }
 
 /** Inline cap for stdout/stderr stored on the `tool_node` message row.

--- a/packages/core/src/parser/yaml.ts
+++ b/packages/core/src/parser/yaml.ts
@@ -134,6 +134,8 @@ const STEP_KEY_TO_IR: Readonly<Record<string, string>> = {
   "system-prompt": "system_prompt",
   "skills-disabled": "skills_disabled",
   run: "tool_command",
+  // `exec:` is a structured key handled separately (not via coerceScalar)
+  // and is added to STEP_RESERVED below.
   "retry-policy": "retry_policy",
   "retry-initial-delay-ms": "retry_initial_delay_ms",
   "retry-backoff-factor": "retry_backoff_factor",
@@ -151,7 +153,7 @@ const GRAPH_KEY_TO_IR: Readonly<Record<string, string>> = {
 };
 
 // Keys consumed by the parser at the step level (not stored in attrs):
-const STEP_RESERVED = new Set(["type", "next", "on", "routes", "retry", "timeout-minutes"]);
+const STEP_RESERVED = new Set(["type", "next", "on", "routes", "retry", "timeout-minutes", "exec"]);
 // Keys consumed at the graph level (not stored in attrs):
 const GRAPH_RESERVED = new Set(["name", "steps", "inputs", "defaults"]);
 
@@ -428,6 +430,46 @@ export function parseWorkflow(source: string): Graph {
     if (typeof retryTo === "string" && retryTo.length > 0) {
       attrs["goal_gate"] = true;
       attrs["retry_target"] = retryTo;
+    }
+    // `exec: {cmd, args}` → tool_argv. Structural key; not passed through
+    // coerceScalar. Mutex with `run:` (which lowers to tool_command) is
+    // enforced by validator E033 rather than here so the E-code pipeline
+    // is the single user-facing error surface.
+    const execNode = body.get("exec", true);
+    if (execNode !== undefined) {
+      if (!YAML.isMap(execNode)) {
+        throw new ParseError(
+          `step "${stepId}" exec: must be a mapping with cmd and args`,
+          ...locArr(locOf(execNode, lineCounter)),
+        );
+      }
+      const rawCmd = scalarValue(execNode.get("cmd", true));
+      if (typeof rawCmd !== "string" || rawCmd.trim().length === 0) {
+        throw new ParseError(
+          `step "${stepId}" exec.cmd must be a non-empty string`,
+          ...locArr(locOf(execNode, lineCounter)),
+        );
+      }
+      const rawArgs = execNode.get("args", true);
+      let parsedArgs: string[];
+      if (rawArgs === undefined || rawArgs === null) {
+        parsedArgs = [];
+      } else if (YAML.isSeq(rawArgs)) {
+        parsedArgs = [];
+        for (const item of rawArgs.items) {
+          const v = scalarValue(item);
+          if (typeof v !== "string" && typeof v !== "number" && typeof v !== "boolean") {
+            throw new ParseError(
+              `step "${stepId}" exec.args must be a sequence of scalar values`,
+              ...locArr(locOf(item, lineCounter)),
+            );
+          }
+          parsedArgs.push(String(v));
+        }
+      } else {
+        throw new ParseError(`step "${stepId}" exec.args must be a sequence`, ...locArr(locOf(rawArgs, lineCounter)));
+      }
+      attrs["tool_argv"] = { cmd: rawCmd, args: parsedArgs };
     }
     // ---- edge synthesis ----
     const nextNode = scalarValue(body.get("next", true));

--- a/packages/core/src/types/execution.ts
+++ b/packages/core/src/types/execution.ts
@@ -28,14 +28,30 @@ export interface ExecutionEnvironment {
   writeFile(path: string, contents: string): Promise<void>;
   /** Check if a file exists. */
   exists(path: string): Promise<boolean>;
-  /** Execute a shell command. Returns stdout/stderr/exit code. The
-   * optional `onData` callback streams chunks as they arrive — tools
+  /** Execute a shell command via `sh -c`. Returns stdout/stderr/exit code.
+   * The optional `onData` callback streams chunks as they arrive — tools
    * use it to surface partial output to the UI during long commands.
    * `signal` triggers process-tree termination; backends should send
    * SIGTERM to the whole process group, then SIGKILL after a short
    * grace window, so stuck child processes don't leak past abort. */
   exec(
     command: string,
+    opts?: {
+      cwd?: string;
+      timeoutMs?: number;
+      env?: Record<string, string>;
+      signal?: AbortSignal;
+      onData?: (chunk: string, kind: "stdout" | "stderr") => void;
+    },
+  ): Promise<ExecResult>;
+  /** Execute a binary directly with NO shell. Each element of `args` is
+   * passed as a separate argv token — values containing spaces, newlines,
+   * `$()`, or shell metacharacters are inert data at the child process.
+   * `cmd` is checked against the blocklist and refused when it is a shell
+   * interpreter (sh/bash/zsh/dash/fish). */
+  spawn(
+    cmd: string,
+    args: string[],
     opts?: {
       cwd?: string;
       timeoutMs?: number;

--- a/packages/core/src/types/graph.ts
+++ b/packages/core/src/types/graph.ts
@@ -58,8 +58,14 @@ export interface NodeAttrs {
    * (SPEC §3.4 chain). References a step id. */
   fallback_retry_target?: string;
   /** Tool-step config (type:tool). Shell command executed by the tool
-   * handler. */
+   * handler via `sh -c`. Mutually exclusive with `tool_argv`. */
   tool_command?: string;
+  /** Tool-step config (type:tool). argv-vector form (authoring: `exec:`).
+   * Executed with no shell — each element is a separate argv token.
+   * Per-element `${{ inputs.* }}` substitution: the substituted value
+   * becomes exactly one token, never re-split. Mutually exclusive with
+   * `tool_command`. */
+  tool_argv?: { cmd: string; args: string[] };
   /** Per-node cumulative cost ceiling in USD. Cumulative across all
    * iterations of this node within the run. */
   max_cost_usd?: number;

--- a/packages/core/src/types/read-only-env.ts
+++ b/packages/core/src/types/read-only-env.ts
@@ -38,5 +38,8 @@ export function makeReadOnlyEnv(env: ExecutionEnvironment): ExecutionEnvironment
     exec: (_command: string): Promise<ExecResult> => {
       throw new ReadOnlyEnvError("exec");
     },
+    spawn: (_cmd: string, _args: string[]): Promise<ExecResult> => {
+      throw new ReadOnlyEnvError("spawn");
+    },
   };
 }

--- a/packages/core/test/engine/substitution.test.ts
+++ b/packages/core/test/engine/substitution.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
-import { inputReferences, substitute } from "../../src/engine/substitution.ts";
+import { inputReferences, substitute, substituteArgv } from "../../src/engine/substitution.ts";
 
 describe("substitute", () => {
   test("no tokens → template unchanged", () => {
@@ -99,6 +99,76 @@ describe("substitute — properties", () => {
         const escapeCount = (out.match(/'\\''/g) ?? []).length;
         expect(escapeCount).toBe(quoteCount);
       }),
+    );
+  });
+});
+
+describe("substituteArgv", () => {
+  test("no tokens — passthrough unchanged", () => {
+    const result = substituteArgv({ cmd: "jq", args: [".name", "in.json"] });
+    expect(result).toEqual({ cmd: "jq", args: [".name", "in.json"] });
+  });
+
+  test("substitutes cmd and each args element independently", () => {
+    const result = substituteArgv(
+      { cmd: "${{ inputs.bin }}", args: ["${{ inputs.filter }}", "${{ inputs.file }}"] },
+      { args: { inputs: { bin: "jq", filter: ".name", file: "out.json" } } },
+    );
+    expect(result).toEqual({ cmd: "jq", args: [".name", "out.json"] });
+  });
+
+  test("per-element: a value with spaces stays one argv element (no re-split)", () => {
+    const result = substituteArgv(
+      { cmd: "echo", args: ["${{ inputs.msg }}"] },
+      { args: { inputs: { msg: "hello world\nrm -rf /" } } },
+    );
+    expect(result.args).toHaveLength(1);
+    expect(result.args[0]).toBe("hello world\nrm -rf /");
+  });
+
+  test("per-element: shell metacharacters are inert (not interpreted)", () => {
+    const dangerous = "$(whoami); rm -rf / | cat && echo `id` 'quote'\"'";
+    const result = substituteArgv(
+      { cmd: "printf", args: ["%s", "${{ inputs.val }}"] },
+      { args: { inputs: { val: dangerous } } },
+    );
+    expect(result.args[1]).toBe(dangerous);
+  });
+
+  test("cmd substitution gives a single token even when value contains a path with spaces", () => {
+    const result = substituteArgv(
+      { cmd: "${{ inputs.bin }}", args: [] },
+      { args: { inputs: { bin: "/usr/local/bin/my tool" } } },
+    );
+    expect(result.cmd).toBe("/usr/local/bin/my tool");
+  });
+
+  test("unresolved reference collapses to empty string (same as substitute)", () => {
+    const result = substituteArgv({ cmd: "jq", args: ["${{ inputs.missing }}"] }, { args: { inputs: {} } });
+    expect(result.args[0]).toBe("");
+  });
+
+  test("no shell-quoting applied — value with single quotes is verbatim", () => {
+    const result = substituteArgv(
+      { cmd: "echo", args: ["${{ inputs.v }}"] },
+      { args: { inputs: { v: "it's a test" } } },
+    );
+    expect(result.args[0]).toBe("it's a test");
+  });
+
+  test("property: substituteArgv never alters the number of argv elements", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ maxLength: 30 }), { minLength: 0, maxLength: 5 }),
+        fc.string({ maxLength: 30 }),
+        (args, value) => {
+          const result = substituteArgv(
+            { cmd: "echo", args: args.map(() => "${{ inputs.v }}") },
+            { args: { inputs: { v: value } } },
+          );
+          expect(result.args).toHaveLength(args.length);
+        },
+      ),
     );
   });
 });

--- a/packages/core/test/engine/validator.test.ts
+++ b/packages/core/test/engine/validator.test.ts
@@ -318,6 +318,143 @@ describe("validate — handler lints", () => {
     expect(codesOf(g)).toContain("E008");
   });
 
+  test("E033 tool node sets both run: and exec: (tool_command + tool_argv)", () => {
+    const g = mkGraph({
+      nodes: {
+        s: "start",
+        run: {
+          type: "tool",
+          attrs: { tool_command: "echo hi", tool_argv: { cmd: "echo", args: ["hi"] } } as NodeAttrs,
+        },
+        done: "exit",
+      },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    const e033 = validate(g).filter((d) => d.code === "E033");
+    expect(e033).toHaveLength(1);
+    expect(e033[0]?.severity).toBe("error");
+    expect(e033[0]?.nodeId).toBe("run");
+  });
+
+  test("E034 tool node with neither run: nor exec: emits E034", () => {
+    const g = mkGraph({
+      nodes: { s: "start", run: { type: "tool", attrs: {} as NodeAttrs }, done: "exit" },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    expect(codesOf(g)).toContain("E034");
+  });
+
+  test("E034 literal exec.cmd is a shell interpreter (bash)", () => {
+    const g = mkGraph({
+      nodes: {
+        s: "start",
+        run: { type: "tool", attrs: { tool_argv: { cmd: "bash", args: ["-c", "ls"] } } as NodeAttrs },
+        done: "exit",
+      },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    const e034 = validate(g).filter((d) => d.code === "E034");
+    expect(e034).toHaveLength(1);
+    expect(e034[0]?.nodeId).toBe("run");
+    expect(e034[0]?.message).toContain("bash");
+  });
+
+  test("E034 literal exec.cmd refused for all shell interpreters", () => {
+    for (const shell of ["sh", "bash", "zsh", "dash", "fish"]) {
+      const g = mkGraph({
+        nodes: {
+          s: "start",
+          run: { type: "tool", attrs: { tool_argv: { cmd: shell, args: [] } } as NodeAttrs },
+          done: "exit",
+        },
+        edges: [
+          ["s", "run"],
+          ["run", "done"],
+        ],
+      });
+      expect(codesOf(g)).toContain("E034");
+    }
+  });
+
+  test("E034 does NOT fire when exec.cmd is interpolated (runtime check handles it)", () => {
+    const g = mkGraph({
+      nodes: {
+        s: "start",
+        run: {
+          type: "tool",
+          attrs: { tool_argv: { cmd: "${{ inputs.bin }}", args: [] } } as NodeAttrs,
+        },
+        done: "exit",
+      },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    expect(codesOf(g)).not.toContain("E034");
+  });
+
+  test("tool node with exec: only and safe cmd is valid (no E033/E034)", () => {
+    const g = mkGraph({
+      nodes: {
+        s: "start",
+        run: { type: "tool", attrs: { tool_argv: { cmd: "jq", args: [".name"] } } as NodeAttrs },
+        done: "exit",
+      },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    expect(codesOf(g)).not.toContain("E033");
+    expect(codesOf(g)).not.toContain("E034");
+  });
+
+  test("E030 scans tool_argv.cmd and tool_argv.args for undeclared inputs", () => {
+    const g = mkGraph({
+      nodes: {
+        s: "start",
+        run: {
+          type: "tool",
+          attrs: { tool_argv: { cmd: "jq", args: ["${{ inputs.missing }}"] } } as NodeAttrs,
+        },
+        done: "exit",
+      },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    expect(codesOf(g)).toContain("E030");
+  });
+
+  test("E030 scans tool_argv.cmd for undeclared inputs", () => {
+    const g = mkGraph({
+      nodes: {
+        s: "start",
+        run: {
+          type: "tool",
+          attrs: { tool_argv: { cmd: "${{ inputs.missing }}", args: [] } } as NodeAttrs,
+        },
+        done: "exit",
+      },
+      edges: [
+        ["s", "run"],
+        ["run", "done"],
+      ],
+    });
+    expect(codesOf(g)).toContain("E030");
+  });
+
   test("E009 human node with no outgoing edges", () => {
     const g = mkGraph({
       nodes: { s: "start", gate: { type: "human", attrs: { kind: "human" } as NodeAttrs }, done: "exit" },

--- a/packages/core/test/handler/context-env-scoping.test.ts
+++ b/packages/core/test/handler/context-env-scoping.test.ts
@@ -19,6 +19,7 @@ function fullEnv(): ExecutionEnvironment {
     writeFile: async () => {},
     exists: async () => true,
     exec: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
+    spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     listDir: async () => [],
     glob: async () => [],
   };

--- a/packages/core/test/handler/tool.test.ts
+++ b/packages/core/test/handler/tool.test.ts
@@ -7,7 +7,13 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentMessage } from "@fragua/types";
 import fc from "fast-check";
-import { makeToolHandler, runWithBun, type SpawnFn, type ToolRunResult } from "../../src/handler/handlers/tool.ts";
+import {
+  type ArgvSpawnFn,
+  makeToolHandler,
+  runWithBun,
+  type SpawnFn,
+  type ToolRunResult,
+} from "../../src/handler/handlers/tool.ts";
 import type { HandlerContext, SideEffectRecorder, ToolRegistry } from "../../src/handler/types.ts";
 import type { ExecutionEnvironment } from "../../src/types/execution.ts";
 
@@ -119,6 +125,7 @@ function makeStubEnv(opts: {
     },
     exists: async () => false,
     exec: async (command, options) => opts.exec(command, options),
+    spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     listDir: async () => [],
     glob: async () => [],
   };
@@ -132,6 +139,13 @@ function fakeSpawner(run: Partial<ToolRunResult>): SpawnFn {
     durationMs: 1,
     ...run,
   });
+}
+
+function fakeArgvSpawner(run: Partial<ToolRunResult>, onCall?: (cmd: string, args: string[]) => void): ArgvSpawnFn {
+  return async (cmd, args) => {
+    onCall?.(cmd, args);
+    return { exitCode: 0, stdout: "", stderr: "", durationMs: 1, ...run };
+  };
 }
 
 describe("makeToolHandler — happy path", () => {
@@ -483,6 +497,141 @@ describe("makeToolHandler — synthetic tool_node message", () => {
     // Artifact has the full 200KB.
     const stdoutArt = ctx.__artifacts.find((a) => a.key === "build:stdout");
     expect(stdoutArt?.content.length).toBe(big.length);
+  });
+});
+
+describe("makeToolHandler — exec form (argv vector)", () => {
+  test("argv path calls argvSpawner with resolved cmd + args, not the shell spawner", async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const shellCalls: string[] = [];
+    const ctx = stubCtx({ nodeId: "fmt" });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "jq", args: [".name", "in.json"] },
+      argvSpawner: fakeArgvSpawner({ exitCode: 0 }, (cmd, args) => calls.push({ cmd, args })),
+      spawner: async (cmd) => {
+        shellCalls.push(cmd);
+        return { exitCode: 0, stdout: "", stderr: "", durationMs: 0 };
+      },
+    });
+    await spec.handler(ctx);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ cmd: "jq", args: [".name", "in.json"] });
+    expect(shellCalls).toHaveLength(0);
+  });
+
+  test("exit 0 → outcome=success", async () => {
+    const ctx = stubCtx({ nodeId: "fmt" });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "true", args: [] },
+      argvSpawner: fakeArgvSpawner({ exitCode: 0 }),
+    });
+    const result = await spec.handler(ctx);
+    expect(result.kind).toBe("transition");
+    if (result.kind === "transition") expect(result.outcomeStatus).toBe("success");
+  });
+
+  test("non-zero exit → outcome=fail", async () => {
+    const ctx = stubCtx({ nodeId: "fmt" });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "false", args: [] },
+      argvSpawner: fakeArgvSpawner({ exitCode: 1 }),
+    });
+    const result = await spec.handler(ctx);
+    expect(result.kind).toBe("transition");
+    if (result.kind === "transition") expect(result.outcomeStatus).toBe("fail");
+  });
+
+  test("per-element substitution: value with spaces becomes one argv element", async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const ctx = stubCtx({
+      nodeId: "fmt",
+      args: { inputs: { msg: "hello world\n$(rm -rf /)" } },
+    });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "echo", args: ["${{ inputs.msg }}"] },
+      argvSpawner: fakeArgvSpawner({ exitCode: 0 }, (cmd, args) => calls.push({ cmd, args })),
+    });
+    await spec.handler(ctx);
+    expect(calls[0]?.args).toHaveLength(1);
+    expect(calls[0]?.args[0]).toBe("hello world\n$(rm -rf /)");
+  });
+
+  test("runtime shell-interpreter refusal: resolved cmd=bash → halt", async () => {
+    const ctx = stubCtx({
+      nodeId: "fmt",
+      args: { inputs: { bin: "bash" } },
+    });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "${{ inputs.bin }}", args: ["-c", "echo hi"] },
+      argvSpawner: fakeArgvSpawner({ exitCode: 0 }),
+    });
+    const result = await spec.handler(ctx);
+    expect(result.kind).toBe("halt");
+    if (result.kind === "halt") expect(result.detail).toContain("shell interpreter");
+  });
+
+  test("runtime shell-interpreter refusal applies to all five names", async () => {
+    for (const shell of ["sh", "bash", "zsh", "dash", "fish"]) {
+      const ctx = stubCtx({ nodeId: "fmt", args: { inputs: { bin: shell } } });
+      const spec = makeToolHandler({
+        toolArgv: { cmd: "${{ inputs.bin }}", args: [] },
+        argvSpawner: fakeArgvSpawner({ exitCode: 0 }),
+      });
+      const result = await spec.handler(ctx);
+      expect(result.kind).toBe("halt");
+    }
+  });
+
+  test("no env + no argvSpawner → halt with clear error", async () => {
+    const ctx = stubCtx({ nodeId: "fmt" });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "jq", args: [] },
+    });
+    const result = await spec.handler(ctx);
+    expect(result.kind).toBe("halt");
+    if (result.kind === "halt") expect(result.detail).toContain("execution environment");
+  });
+
+  test("argv form stores stdout artifact and appends tool_node message", async () => {
+    const ctx = stubCtx({ nodeId: "fmt" });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "jq", args: [".name"] },
+      argvSpawner: fakeArgvSpawner({ exitCode: 0, stdout: '"Alice"', stderr: "" }),
+    });
+    await spec.handler(ctx);
+    const art = ctx.__artifacts.find((a) => a.key === "fmt:stdout");
+    expect(art?.content).toBe('"Alice"');
+    expect(ctx.__messages).toHaveLength(1);
+  });
+
+  test("env.spawn is called (not env.exec) on the argv path", async () => {
+    const spawnCalls: { cmd: string; args: string[] }[] = [];
+    const execCalls: string[] = [];
+    const env: ExecutionEnvironment = {
+      cwd: () => "/wt",
+      projectCwd: () => "/wt",
+      readFile: async () => "",
+      writeFile: async () => {},
+      exists: async () => false,
+      exec: async (cmd) => {
+        execCalls.push(cmd);
+        return { stdout: "", stderr: "", exitCode: 0, durationMs: 0 };
+      },
+      spawn: async (cmd, args) => {
+        spawnCalls.push({ cmd, args });
+        return { stdout: "", stderr: "", exitCode: 0, durationMs: 0 };
+      },
+      listDir: async () => [],
+      glob: async () => [],
+    };
+    const ctx = stubCtx({ nodeId: "fmt", env });
+    const spec = makeToolHandler({
+      toolArgv: { cmd: "jq", args: [".name"] },
+    });
+    await spec.handler(ctx);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]).toEqual({ cmd: "jq", args: [".name"] });
+    expect(execCalls).toHaveLength(0);
   });
 });
 

--- a/packages/core/test/parser/yaml.test.ts
+++ b/packages/core/test/parser/yaml.test.ts
@@ -121,6 +121,112 @@ steps:
     expect(g.nodes["build"]?.attrs.tool_command).toBe("bun run build");
   });
 
+  test("`exec:` lowers to tool_argv with cmd + args[]", () => {
+    const g = parseWorkflow(`
+name: t
+steps:
+  format:
+    type: tool
+    exec:
+      cmd: jq
+      args:
+        - .name
+        - in.json
+    next: done
+  done:
+    type: exit
+`);
+    const argv = g.nodes["format"]?.attrs.tool_argv;
+    expect(argv).toBeDefined();
+    expect(argv?.cmd).toBe("jq");
+    expect(argv?.args).toEqual([".name", "in.json"]);
+    expect(g.nodes["format"]?.attrs.tool_command).toBeUndefined();
+  });
+
+  test("`exec:` with no args parses to empty args array", () => {
+    const g = parseWorkflow(`
+name: t
+steps:
+  format:
+    type: tool
+    exec:
+      cmd: jq
+    next: done
+  done:
+    type: exit
+`);
+    const argv = g.nodes["format"]?.attrs.tool_argv;
+    expect(argv?.cmd).toBe("jq");
+    expect(argv?.args).toEqual([]);
+  });
+
+  test("`exec:` with ${{ inputs.* }} tokens parses as-is (substitution is runtime)", () => {
+    // Use string concatenation to avoid JS template literal eating the ${{ }} token.
+    const source = [
+      "name: t",
+      "inputs:",
+      "  file:",
+      "    type: string",
+      "    required: true",
+      "steps:",
+      "  format:",
+      "    type: tool",
+      "    exec:",
+      "      cmd: jq",
+      "      args:",
+      "        - .name",
+      "        - ${{ inputs.file }}",
+      "    next: done",
+      "  done:",
+      "    type: exit",
+    ].join("\n");
+    const g = parseWorkflow(source);
+    const argv = g.nodes["format"]?.attrs.tool_argv;
+    expect(argv?.args).toEqual([".name", "${{ inputs.file }}"]);
+  });
+
+  test("`exec:` with missing cmd is a parse error", () => {
+    expect(() =>
+      parseWorkflow(`
+name: t
+steps:
+  format:
+    type: tool
+    exec:
+      args: [foo]
+    next: done
+`),
+    ).toThrow();
+  });
+
+  test("`exec:` with non-mapping value is a parse error", () => {
+    expect(() =>
+      parseWorkflow(`
+name: t
+steps:
+  format:
+    type: tool
+    exec: "jq .name in.json"
+    next: done
+`),
+    ).toThrow();
+  });
+
+  test("`exec:` with non-array args is a parse error", () => {
+    expect(() =>
+      parseWorkflow(`
+name: t
+steps:
+  format:
+    type: tool
+    exec:
+      cmd: jq
+      args: not-a-sequence
+    next: done
+`),
+    ).toThrow();
+  });
+
   test("defaults: block populates llm steps when attr is absent", () => {
     const g = parseWorkflow(`
 name: t

--- a/packages/core/test/types/read-only-env.test.ts
+++ b/packages/core/test/types/read-only-env.test.ts
@@ -14,6 +14,7 @@ function fullEnv(): ExecutionEnvironment {
     },
     exists: async (p) => files.has(p),
     exec: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
+    spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     listDir: async () => [],
     glob: async () => [],
   };

--- a/packages/daemon/src/auto-dispatcher.ts
+++ b/packages/daemon/src/auto-dispatcher.ts
@@ -184,6 +184,7 @@ function specForNode(
     text?: string;
     routes?: string[];
     tool_command?: string;
+    tool_argv?: { cmd: string; args: string[] };
   },
   resolvedMaxMs: number | undefined,
 ): HandlerSpec {
@@ -217,8 +218,12 @@ function specForNode(
       }
     }
     case "tool": {
-      const cmd = typeof attrs.tool_command === "string" ? attrs.tool_command : "";
-      const toolOpts: Parameters<typeof handler.makeToolHandler>[0] = { toolCommand: cmd };
+      const toolOpts: Parameters<typeof handler.makeToolHandler>[0] = {};
+      if (attrs.tool_argv !== undefined) {
+        toolOpts.toolArgv = attrs.tool_argv;
+      } else {
+        toolOpts.toolCommand = typeof attrs.tool_command === "string" ? attrs.tool_command : "";
+      }
       if (resolvedMaxMs !== undefined) toolOpts.maxMs = resolvedMaxMs;
       return handler.makeToolHandler(toolOpts);
     }

--- a/packages/daemon/test/executor-regression-repro.test.ts
+++ b/packages/daemon/test/executor-regression-repro.test.ts
@@ -52,6 +52,7 @@ function stubEnv(cwd: string): ExecutionEnvironment {
     writeFile: async () => {},
     exists: async () => false,
     exec: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
+    spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     listDir: async () => [],
     glob: async () => [],
   };

--- a/packages/daemon/test/executor-worktree.test.ts
+++ b/packages/daemon/test/executor-worktree.test.ts
@@ -23,6 +23,7 @@ function stubEnv(cwd: string, extras: Record<string, unknown> = {}): ExecutionEn
     writeFile: async () => {},
     exists: async () => false,
     exec: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
+    spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     listDir: async () => [],
     glob: async () => [],
   };

--- a/packages/daemon/test/worktree-provisioner.test.ts
+++ b/packages/daemon/test/worktree-provisioner.test.ts
@@ -39,6 +39,7 @@ function stubEnv(cwd: string): ExecutionEnvironment {
     writeFile: async () => {},
     exists: async () => false,
     exec: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
+    spawn: async () => ({ stdout: "", stderr: "", exitCode: 0, durationMs: 0 }),
     listDir: async () => [],
     glob: async () => [],
   };

--- a/packages/web/src/components/GraphView.tsx
+++ b/packages/web/src/components/GraphView.tsx
@@ -766,7 +766,12 @@ export function toFlowGraph(
       provider: isLlmHandler ? a?.provider : undefined,
       reasoningEffort: isLlmHandler ? a?.reasoning_effort : undefined,
       threadId: isLlmHandler && typeof a?.thread_id === "string" ? a.thread_id : undefined,
-      toolCommand: handler === "tool" && typeof a?.tool_command === "string" ? truncate(a.tool_command, 40) : undefined,
+      toolCommand:
+        handler === "tool" && typeof a?.tool_command === "string"
+          ? truncate(a.tool_command, 40)
+          : handler === "tool" && a?.tool_argv !== undefined
+            ? truncate([a.tool_argv.cmd, ...a.tool_argv.args].join(" "), 40)
+            : undefined,
       // goal_gate (and therefore the §3.4 retarget chain) is only meaningful
       // on llm nodes today — `typeStripTone` documents the precedence.
       retryTarget:

--- a/packages/web/src/components/NodeInspector.tsx
+++ b/packages/web/src/components/NodeInspector.tsx
@@ -134,6 +134,22 @@ export function NodeInspector({ node, state, className }: NodeInspectorProps): J
           />
         </Section>
       )}
+      {/* Tool (exec: argv-vector form) */}
+      {attrs.tool_argv !== undefined && (
+        <Section title="tool (exec)">
+          <Field
+            label="argv"
+            value={
+              <pre
+                className="whitespace-pre-wrap break-words rounded bg-sw-surface-muted p-sw-xs text-sw-xs text-sw-text"
+                data-testid="node-inspector-tool-argv"
+              >
+                {[attrs.tool_argv.cmd, ...attrs.tool_argv.args].join(" ")}
+              </pre>
+            }
+          />
+        </Section>
+      )}
 
       {/* Tools */}
       {(allowedTools.length > 0 || deniedTools.length > 0) && (

--- a/packages/workspace/src/blocklist.ts
+++ b/packages/workspace/src/blocklist.ts
@@ -1,5 +1,6 @@
 // Command blocklist — refuses the most dangerous shell patterns even in
 // unsafe permission mode. Each entry is a regex source tested case-insensitively.
+import { basename } from "node:path";
 
 export const DEFAULT_BLOCKED_PATTERNS: readonly string[] = [
   // rm -rf against critical paths
@@ -16,6 +17,19 @@ export const DEFAULT_BLOCKED_PATTERNS: readonly string[] = [
   // fork bomb
   ":\\(\\)\\s*\\{\\s*:\\|:&\\s*\\};:",
 ];
+
+/** Shell interpreter binary names refused as `exec.cmd`. Case-insensitive
+ * basename match; `.exe` suffix stripped for Windows compatibility. */
+export const SHELL_INTERPRETERS: readonly string[] = ["sh", "bash", "zsh", "dash", "fish"];
+
+/** Return true when `cmd` is a shell interpreter. Matches on basename
+ * (so `/usr/bin/bash` and `bash` both match) and is case-insensitive.
+ * Strips a trailing `.exe` suffix before matching. */
+export function isShellInterpreter(cmd: string): boolean {
+  let name = basename(cmd).toLowerCase();
+  if (name.endsWith(".exe")) name = name.slice(0, -4);
+  return SHELL_INTERPRETERS.includes(name);
+}
 
 /** Return the first pattern that matches, or undefined if command is allowed. */
 export function isBlockedCommand(command: string, extra: readonly string[] = []): string | undefined {

--- a/packages/workspace/src/local-env.ts
+++ b/packages/workspace/src/local-env.ts
@@ -5,7 +5,7 @@ import { spawn } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { isBlockedCommand } from "./blocklist.ts";
+import { isBlockedCommand, isShellInterpreter } from "./blocklist.ts";
 import type { DirEntry, ExecResult, ExecutionEnvironment } from "./types.ts";
 
 /**
@@ -254,6 +254,144 @@ export class LocalEnvironment implements ExecutionEnvironment {
           }
           // Escalate to SIGKILL after a short grace window. If the
           // process already exited the second kill is harmless.
+          setTimeout(() => {
+            if (child.pid !== undefined) {
+              try {
+                process.kill(-child.pid, "SIGKILL");
+              } catch {
+                try {
+                  child.kill("SIGKILL");
+                } catch {
+                  // ignore
+                }
+              }
+            }
+          }, 2_000);
+        }
+      };
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        killTree("timeout");
+      }, timeoutMs);
+
+      const onAbort = () => {
+        if (settled) return;
+        killTree("abort");
+      };
+      if (opts.signal) {
+        if (opts.signal.aborted) onAbort();
+        else opts.signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      child.stdout.on("data", (chunk) => {
+        const s = chunk.toString();
+        stdout += s;
+        opts.onData?.(s, "stdout");
+      });
+      child.stderr.on("data", (chunk) => {
+        const s = chunk.toString();
+        stderr += s;
+        opts.onData?.(s, "stderr");
+      });
+      child.on("close", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+        if (killReason === "timeout") {
+          resolvePromise({
+            stdout,
+            stderr: `${stderr}\n[fragua: exec timed out after ${timeoutMs}ms]`,
+            exitCode: 124,
+            durationMs: Date.now() - start,
+          });
+          return;
+        }
+        if (killReason === "abort") {
+          resolvePromise({
+            stdout,
+            stderr: `${stderr}\n[fragua: exec aborted]`,
+            exitCode: 130,
+            durationMs: Date.now() - start,
+          });
+          return;
+        }
+        resolvePromise({ stdout, stderr, exitCode: code ?? 0, durationMs: Date.now() - start });
+      });
+      child.on("error", (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+        resolvePromise({ stdout, stderr: err.message, exitCode: 127, durationMs: Date.now() - start });
+      });
+    });
+  }
+
+  /** Execute a binary directly with NO shell. Each element of `args` is a
+   * separate argv token — values containing spaces, newlines, `$()`, or any
+   * shell metacharacter are inert data at the child process. Blocklist
+   * patterns are applied to `cmd` only. Shell interpreters
+   * (sh/bash/zsh/dash/fish) are refused even if not in the blocklist, to
+   * preserve the invariant that all shell execution goes through `exec()`. */
+  async spawn(
+    cmd: string,
+    args: string[],
+    opts: {
+      cwd?: string;
+      timeoutMs?: number;
+      env?: Record<string, string>;
+      signal?: AbortSignal;
+      onData?: (chunk: string, kind: "stdout" | "stderr") => void;
+    } = {},
+  ): Promise<ExecResult> {
+    if (isShellInterpreter(cmd)) {
+      return {
+        stdout: "",
+        stderr: `[fragua: blocked command — exec.cmd "${cmd}" is a shell interpreter. Use \`run:\` for shell commands so the blocklist scan applies.]`,
+        exitCode: 126,
+        durationMs: 0,
+      };
+    }
+    const blocked = isBlockedCommand(cmd, this.extraBlocked);
+    if (blocked) {
+      return {
+        stdout: "",
+        stderr: `[fragua: blocked command — matched pattern "${blocked}". Edit .fragua/config.yaml blocklist to adjust.]`,
+        exitCode: 126,
+        durationMs: 0,
+      };
+    }
+    const cwd = opts.cwd ? this.resolvePath(opts.cwd) : this._cwd;
+    const timeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    const start = Date.now();
+
+    return new Promise((resolvePromise) => {
+      const child = spawn(cmd, args, {
+        cwd,
+        env: { ...process.env, ...opts.env },
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+        shell: false,
+      });
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      let killReason: "timeout" | "abort" | undefined;
+
+      const killTree = (reason: "timeout" | "abort") => {
+        killReason = reason;
+        if (child.pid !== undefined) {
+          try {
+            process.kill(-child.pid, "SIGTERM");
+          } catch {
+            try {
+              child.kill("SIGTERM");
+            } catch {
+              // ignore
+            }
+          }
           setTimeout(() => {
             if (child.pid !== undefined) {
               try {

--- a/packages/workspace/src/worktree-env.ts
+++ b/packages/workspace/src/worktree-env.ts
@@ -236,6 +236,20 @@ export class WorktreeEnvironment implements ExecutionEnvironment {
   ): Promise<ExecResult> {
     return this.local.exec(command, opts);
   }
+
+  spawn(
+    cmd: string,
+    args: string[],
+    opts?: {
+      cwd?: string;
+      timeoutMs?: number;
+      env?: Record<string, string>;
+      signal?: AbortSignal;
+      onData?: (chunk: string, kind: "stdout" | "stderr") => void;
+    },
+  ): Promise<ExecResult> {
+    return this.local.spawn(cmd, args, opts);
+  }
 }
 
 function runGit(cwd: string, args: string[], extraEnv?: Record<string, string>): Promise<void> {

--- a/packages/workspace/test/blocklist.test.ts
+++ b/packages/workspace/test/blocklist.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { isBlockedCommand, isShellInterpreter, SHELL_INTERPRETERS } from "../src/blocklist.ts";
+
+describe("isShellInterpreter", () => {
+  test("matches each of the five shell names exactly", () => {
+    for (const shell of ["sh", "bash", "zsh", "dash", "fish"]) {
+      expect(isShellInterpreter(shell)).toBe(true);
+    }
+  });
+
+  test("case-insensitive match", () => {
+    expect(isShellInterpreter("BASH")).toBe(true);
+    expect(isShellInterpreter("Zsh")).toBe(true);
+    expect(isShellInterpreter("SH")).toBe(true);
+  });
+
+  test("matches basename of an absolute path", () => {
+    expect(isShellInterpreter("/usr/bin/bash")).toBe(true);
+    expect(isShellInterpreter("/bin/sh")).toBe(true);
+  });
+
+  test("strips .exe suffix before matching", () => {
+    expect(isShellInterpreter("bash.exe")).toBe(true);
+    expect(isShellInterpreter("sh.exe")).toBe(true);
+  });
+
+  test("does not match non-shell names", () => {
+    expect(isShellInterpreter("bashful")).toBe(false);
+    expect(isShellInterpreter("myzsh")).toBe(false);
+    expect(isShellInterpreter("node")).toBe(false);
+    expect(isShellInterpreter("python")).toBe(false);
+    expect(isShellInterpreter("bun")).toBe(false);
+  });
+
+  test("SHELL_INTERPRETERS constant has exactly the five expected names", () => {
+    expect([...SHELL_INTERPRETERS].sort()).toEqual(["bash", "dash", "fish", "sh", "zsh"]);
+  });
+});
+
+describe("isBlockedCommand — argv context (cmd only, not joined string)", () => {
+  test("sudo as cmd is blocked", () => {
+    expect(isBlockedCommand("sudo")).toBeDefined();
+  });
+
+  test("a blocklist pattern matching cmd body is blocked", () => {
+    // rm -rf / matches the rm -rf pattern
+    expect(isBlockedCommand("rm -rf /")).toBeDefined();
+  });
+
+  test("blocklist does not fire on a safe cmd", () => {
+    expect(isBlockedCommand("jq")).toBeUndefined();
+    expect(isBlockedCommand("echo")).toBeUndefined();
+  });
+
+  test("blocklist checks cmd only (argv elements are intentionally not joined)", () => {
+    // 'sudo' as an arg element won't be passed to isBlockedCommand in the exec path —
+    // only the cmd (argv[0]) is checked. This test confirms the function itself
+    // matches on substring patterns so the caller's responsibility is to pass only cmd.
+    expect(isBlockedCommand("echo")).toBeUndefined();
+    // If someone erroneously passed the full joined string, sudo in args would still match.
+    // The exec path avoids this by calling isBlockedCommand(cmd) not isBlockedCommand(joined).
+  });
+});

--- a/packages/workspace/test/local-env.test.ts
+++ b/packages/workspace/test/local-env.test.ts
@@ -127,3 +127,67 @@ describe("LocalEnvironment", () => {
     });
   });
 });
+
+describe("LocalEnvironment.spawn", () => {
+  let scratch: string;
+  let env: LocalEnvironment;
+
+  beforeEach(async () => {
+    scratch = await mkdtemp(join(tmpdir(), "fragua-spawn-"));
+    env = new LocalEnvironment({ cwd: scratch });
+  });
+
+  afterEach(async () => {
+    await rm(scratch, { recursive: true, force: true });
+  });
+
+  test("executes argv vector with no shell interpretation", async () => {
+    const r = await env.spawn("printf", ["%s\n", "a;b|c$(whoami)"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("a;b|c$(whoami)");
+  });
+
+  test("exit 0 → exitCode 0; non-zero exit → non-zero exitCode", async () => {
+    const ok = await env.spawn("true", []);
+    expect(ok.exitCode).toBe(0);
+    const fail = await env.spawn("false", []);
+    expect(fail.exitCode).not.toBe(0);
+  });
+
+  test("refuses shell interpreter as cmd — returns exitCode 126", async () => {
+    const r = await env.spawn("bash", ["-c", "echo hi"]);
+    expect(r.exitCode).toBe(126);
+    expect(r.stderr).toContain("[fragua: blocked");
+    expect(r.stderr).toContain("shell interpreter");
+  });
+
+  test("refuses all five shell interpreters", async () => {
+    for (const shell of ["sh", "bash", "zsh", "dash", "fish"]) {
+      const r = await env.spawn(shell, []);
+      expect(r.exitCode).toBe(126);
+    }
+  });
+
+  test("applies blocklist to cmd only, not argv elements", async () => {
+    const ok = await env.spawn("echo", ["sudo", "rm -rf /"]);
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout).toContain("sudo");
+  });
+
+  test("blocklist pattern matching cmd is refused", async () => {
+    const r = await env.spawn("sudo", ["ls"]);
+    expect(r.exitCode).toBe(126);
+  });
+
+  test("timeout kills the process", async () => {
+    const r = await env.spawn("sleep", ["10"], { timeoutMs: 150 });
+    expect(r.exitCode).toBe(124);
+    expect(r.stderr).toContain("timed out");
+  }, 5_000);
+
+  test("captures stdout", async () => {
+    const r = await env.spawn("printf", ["hello\n"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("hello");
+  });
+});


### PR DESCRIPTION
Adds `exec: {cmd, args}` as a mutually-exclusive alternative to `run:` on tool nodes. The argv vector spawns a binary directly with **no shell**, so `${{ inputs.* }}` values substitute per-element — each becomes exactly one inert argv token, never re-split or shell-parsed. This is the injection-safe form for steps interpolating generated/untrusted content; `run:` stays the right choice for shell idioms (pipes, redirects, globs).

## What's in it
- **parser**: lower `exec:` → `tool_argv` (cmd + args[])
- **substitution**: `substituteArgv` (per-element, no shell-quoting)
- **validator**: `E033` (both `run`+`exec`), `E034` (neither, or a literal shell interpreter as `exec.cmd`) — `E008` kept firing alongside `E034` for back-compat
- **env**: `ExecutionEnvironment.spawn()` (no shell, kill-tree on abort/timeout) on Local + Worktree envs; read-only env throws; blocklist + shell-interpreter refusal on `cmd`
- **handler**: exec branch routes through `env.spawn()`; runtime shell-interpreter refusal mirrors `E034` for interpolated `cmd` values
- **web**: GraphView + NodeInspector render the argv form
- **docs**: SPEC §3.1/§3.8, workflows SKILL, validator-codes; proposal marked `shipped` (the `idempotent:` marker remains the deferred follow-up)

## Verification
- monorepo typecheck clean
- `bun test packages/core packages/workspace packages/daemon` → 1007 pass
- biome lint clean

Lands fragua run `01ksgk40cbdsmr74kyascqr8w5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)