### PR TITLE
release: SHA256SUMS + Sigstore provenance; verify + pin-by-default

### DIFF
--- a/.github/actions/setup-fragua/README.md
+++ b/.github/actions/setup-fragua/README.md
@@ -6,25 +6,48 @@ runs a workflow to completion and exits with a code that reflects the outcome
 (0 completed, non-zero on halt/quarantine/pause) — so a fragua run gates a job
 the same way a test suite does.
 
+## Install
+
+> **Pin to a release tag — do not float `latest`.**
+>
+> Floating `latest` silently rolls your consumers onto every new fragua release
+> the moment it publishes, including any that change prompt behaviour, tool
+> surface, or agent reasoning. A code-review workflow that passes on one engine
+> may fail, produce different verdicts, or use a different tool on the next. Pin
+> the tag so the engine your team reviewed is the engine your CI runs.
+
 ```yaml
 steps:
   - uses: actions/checkout@v6
-  - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.2.0
+  - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.2.0   # ← pin the tag
   - run: fragua ci my-workflow
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
+
+To upgrade, update the tag in one commit and review the diff the way you would
+any other dependency bump.
 
 `actions/checkout` must run first: `fragua ci` provisions a git worktree per run
 under the checkout, so it needs a git repository to work in. The workflow name
 resolves against `.fragua/workflows/<name>.yaml` in the checkout (and
 `~/.fragua/workflows/`), exactly as the local CLI resolves it.
 
+## Supply-chain integrity
+
+`setup-fragua` verifies the downloaded binary against the `SHA256SUMS` file
+published alongside every release before marking it executable. A digest
+mismatch or a missing checksum entry fails the step immediately (`exit 1`) —
+the binary is never executed if it cannot be verified. Every release binary is
+also covered by a [Sigstore](https://www.sigstore.dev/) build provenance
+attestation emitted via `actions/attest-build-provenance`, which ties each
+binary's digest to the specific workflow run that produced it.
+
 ## Inputs
 
 | Input | Default | Description |
 |---|---|---|
-| `version` | `latest` | Release tag to install (e.g. `v0.2.0`), or `latest` for the newest release. Pin it for reproducible CI. |
+| `version` | `latest` | Release tag to install (e.g. `v0.2.0`), or `latest` for the newest release. **Pin this** for reproducible CI. |
 | `web` | `false` | `false` installs the smaller **headless** binary (no `harness`/`serve` UI — fine for `fragua ci`). `true` installs the full binary with the web UI. |
 | `token` | `${{ github.token }}` | Token used to download the release asset. The default works when the consumer repo can read the fragua repo's releases. |
 

--- a/.github/actions/setup-fragua/action.yml
+++ b/.github/actions/setup-fragua/action.yml
@@ -57,17 +57,38 @@ runs:
 
         dir="$RUNNER_TEMP/fragua-bin"
         mkdir -p "$dir"
+
+        # Download the chosen binary and the SHA256SUMS file together so we
+        # can verify integrity before making the binary executable.
         gh release download "$tag" \
           --repo "$FRAGUA_REPO" \
           --pattern "$asset" \
-          --output "$dir/fragua" \
+          --pattern "SHA256SUMS" \
+          --dir "$dir" \
           --clobber
+
+        # Verify the downloaded binary against the checksum file.
+        # Fail closed: missing entry or digest mismatch both exit 1.
+        if ! grep -qF "$asset" "$dir/SHA256SUMS"; then
+          echo "::error::setup-fragua: no checksum entry for $asset in SHA256SUMS"
+          exit 1
+        fi
+
+        # sha256sum --check expects lines in the form "<digest>  <filename>".
+        # Filter to only the line for this asset and run from the download dir
+        # so the embedded filename resolves correctly.
+        if ! (cd "$dir" && grep -F "$asset" SHA256SUMS | sha256sum --check --status); then
+          echo "::error::setup-fragua: SHA256 mismatch for $asset — binary may have been tampered with"
+          exit 1
+        fi
+
+        mv "$dir/$asset" "$dir/fragua"
         chmod +x "$dir/fragua"
         echo "$dir" >> "$GITHUB_PATH"
 
         echo "version=$tag" >> "$GITHUB_OUTPUT"
         echo "path=$dir" >> "$GITHUB_OUTPUT"
-        echo "setup-fragua: installed $asset ($tag) → $dir"
+        echo "setup-fragua: installed $asset ($tag) → $dir (checksum verified)"
 
     - shell: bash
       run: fragua --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write # create the release + upload binary assets
+  contents: write    # create the release + upload binary assets
+  id-token: write    # needed by actions/attest-build-provenance to mint an OIDC token
+  attestations: write # needed by actions/attest-build-provenance to write attestations
 
 jobs:
   # Create (or reuse) the GitHub Release first so the matrix jobs below race
@@ -90,3 +92,65 @@ jobs:
             dist/fragua-${{ matrix.target }} \
             dist/fragua-headless-${{ matrix.target }} \
             --clobber
+
+  # After all 8 binaries are uploaded, download them all, generate a single
+  # SHA256SUMS covering every asset, upload it to the release, and emit build
+  # provenance attestations via actions/attest-build-provenance (Sigstore).
+  # Running in one job after the matrix ensures a complete, authoritative
+  # checksum file rather than 4 partial ones racing to the release.
+  checksums-and-attest:
+    needs: binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Download all release binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          for target in bun-linux-x64 bun-linux-arm64 bun-darwin-arm64 bun-darwin-x64; do
+            gh release download "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "fragua-$target" \
+              --pattern "fragua-headless-$target" \
+              --dir dist \
+              --clobber
+          done
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd dist
+          sha256sum fragua-bun-linux-x64 \
+                    fragua-headless-bun-linux-x64 \
+                    fragua-bun-linux-arm64 \
+                    fragua-headless-bun-linux-arm64 \
+                    fragua-bun-darwin-arm64 \
+                    fragua-headless-bun-darwin-arm64 \
+                    fragua-bun-darwin-x64 \
+                    fragua-headless-bun-darwin-x64 \
+            > SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            dist/SHA256SUMS \
+            --clobber
+
+      # Emit a Sigstore build provenance attestation for every binary.
+      # actions/attest-build-provenance links each file's digest to this
+      # workflow run via OIDC, so consumers can verify the binary wasn't
+      # tampered with after leaving GitHub Actions.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/fragua-bun-linux-x64
+            dist/fragua-headless-bun-linux-x64
+            dist/fragua-bun-linux-arm64
+            dist/fragua-headless-bun-linux-arm64
+            dist/fragua-bun-darwin-arm64
+            dist/fragua-headless-bun-darwin-arm64
+            dist/fragua-bun-darwin-x64
+            dist/fragua-headless-bun-darwin-x64

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ fragua run work --input task="add a touch tool to @fragua/workspace"
 
 run discovery is automatic (via the global DB), so `fragua run` works from any directory. point it at a `.yaml` path or a bare name resolved under `~/.fragua/workflows/` then `<cwd>/.fragua/workflows/`. inputs: `-i name=value` (repeatable, `@path` reads a file, `@-` reads stdin). `--title` names the run, `--no-follow` prints the id and exits.
 
+## Install in CI
+
+Pin the action to a release tag in consumer repos:
+
+```yaml
+- uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.2.0
+```
+
+See [`.github/actions/setup-fragua/README.md`](.github/actions/setup-fragua/README.md) for inputs, credential wiring, and artifact export.
+
 ## workflows
 
 ships under `.fragua/workflows/` — run from the repo, or copy into `~/.fragua/workflows/` to use anywhere.


### PR DESCRIPTION
Hardens the release/distribution path so a `setup-fragua` consumer can trust the binary it runs.

## What's in it
- **release.yml**: after the binary matrix, a single `checksums-and-attest` job downloads all 8 assets, generates one authoritative `SHA256SUMS`, uploads it to the release, and emits `actions/attest-build-provenance` (Sigstore) over every binary. Adds `id-token`/`attestations` write permissions.
- **setup-fragua**: downloads `SHA256SUMS` alongside the binary and verifies it before `chmod +x` — **fail closed** (exit 1) on a missing entry or digest mismatch; the binary is never executed unverified.
- **docs**: pin-the-tag guidance (don't float `latest`) in the action README + an "Install in CI" section in the top-level README.

## Verification
- `release.yml` and `action.yml` parse as valid YAML

Lands fragua run `01ksm62vjmy0ht6s1665sh2p4b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)