### PR TITLE
inbox: deliver fact.snapshot_recorded over SSE

### DIFF
--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1030,4 +1030,11 @@ export const FEED_EVENT_KINDS: readonly AnyEventType[] = [
   // Post-terminal operator actions (accept / discard)
   "fact.run_discarded",
   "fact.run_accepted",
+  // Terminal worktree snapshot: written AFTER fact.run_completed in the
+  // executor's finally-block dispose path. It sets inbox_status=pending on
+  // run_state, so the client's inbox=pending list query must refetch when
+  // this fact arrives. Without this entry the server silently drops the
+  // event before it reaches the browser and the completed run never
+  // appears in the Watchtower / /inbox Ready-to-land section.
+  "fact.snapshot_recorded",
 ];

--- a/packages/web/test/lib/useGlobalEventStream.invalidate.test.ts
+++ b/packages/web/test/lib/useGlobalEventStream.invalidate.test.ts
@@ -3,8 +3,14 @@
 // Verifies that every event kind that should trigger a runs-list/detail
 // cache invalidation is present in the exported set.  Pure membership
 // check: no DOM, no React, no fetch mocks required.
+//
+// Invariant: every kind that the client LISTENS FOR in __invalidateKinds
+// must also be in FEED_EVENT_KINDS (the server-side SSE allow-list).
+// Otherwise the server silently drops the event before it reaches the
+// client and the invalidation never fires — stale UI.
 
 import { describe, expect, test } from "bun:test";
+import { FEED_EVENT_KINDS } from "@fragua/types";
 import { __invalidateKinds } from "../../src/lib/useGlobalEventStream.ts";
 
 describe("useGlobalEventStream — RUN_INVALIDATE_KINDS membership", () => {
@@ -37,5 +43,32 @@ describe("useGlobalEventStream — RUN_INVALIDATE_KINDS membership", () => {
   // Auto-titler: run card title updates live after enqueue
   test("includes run.title_generated so titles appear live in run cards", () => {
     expect(__invalidateKinds.has("run.title_generated")).toBe(true);
+  });
+
+  // ── SSE delivery invariant ────────────────────────────────────────
+  //
+  // Every kind in __invalidateKinds that is a "fact.*" event MUST be
+  // present in FEED_EVENT_KINDS (the server-side SSE allow-list in
+  // packages/types/src/events.ts).  If it isn't, the server silently
+  // drops the event before it reaches the browser, so the client's
+  // invalidation handler never fires and the Inbox (or any other
+  // query-driven section) stays stale after that fact lands.
+  //
+  // The canonical failure: fact.snapshot_recorded sets
+  // inbox_status=pending on run_state AFTER fact.run_completed, but
+  // the SSE stream never delivers it because it is absent from
+  // FEED_EVENT_KINDS.  The inbox=pending list query therefore never
+  // refetches and the completed run's worktree item never appears in
+  // Watchtower or /inbox without a manual reload.
+  test("every fact.* kind in RUN_INVALIDATE_KINDS is present in FEED_EVENT_KINDS so the SSE stream delivers it", () => {
+    const feedSet = new Set<string>(FEED_EVENT_KINDS);
+    const missingFromFeed: string[] = [];
+    for (const kind of __invalidateKinds) {
+      if (!kind.startsWith("fact.")) continue;
+      if (!feedSet.has(kind)) {
+        missingFromFeed.push(kind);
+      }
+    }
+    expect(missingFromFeed).toEqual([]);
   });
 });


### PR DESCRIPTION
The terminal worktree snapshot writes `inbox_status=pending` on `run_state` in the executor's dispose path, **after** `fact.run_completed`. But `fact.snapshot_recorded` was absent from `FEED_EVENT_KINDS` (the server-side SSE allow-list), so the server silently dropped it before the browser — the client's `inbox=pending` list query never refetched, and a completed run's worktree item never appeared in Watchtower / `/inbox` without a manual reload.

## Fix
- Add `fact.snapshot_recorded` to `FEED_EVENT_KINDS`.
- Add a regression test asserting the invariant: **every `fact.*` kind the client listens for in `__invalidateKinds` must be present in `FEED_EVENT_KINDS`** — otherwise the SSE stream drops it and the invalidation never fires (stale UI).

## Verification
- `@fragua/types` + `@fragua/web` typecheck clean
- `bun test packages/types packages/server` → 292 pass; the invalidate-membership suite → 5 pass
- biome lint clean

Lands fragua run `01ksm6cq6d367dhxgtt7xz8kc1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)