### PR TITLE
[cli] ci: add --allow-env to exempt secrets from the perimeter env-strip

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,13 +48,19 @@ jobs:
 
       - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.3.1
 
+      # `fragua ci` strips secret-named env (anything ending _TOKEN / _KEY / …) from
+      # tool subprocesses, which removes GH_TOKEN from the `gh pr diff/view/review`
+      # calls pr_review makes. `--allow-env GH_TOKEN` exempts it from the strip only —
+      # the value is still a scrub needle, so it stays redacted from the exported
+      # bundle. NOTE: needs a fragua release that has --allow-env (the version this
+      # change ships); bump the setup-fragua pin above to that release when cutting it.
       - name: "Review PR #${{ github.event.pull_request.number }}"
-        run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }} --export "$RUNNER_TEMP/pr-review.fragua"
+        run: fragua ci pr_review --input pr=${{ github.event.pull_request.number }} --allow-env GH_TOKEN --export "$RUNNER_TEMP/pr-review.fragua"
         env:
           # Swap for ANTHROPIC_OAUTH_TOKEN to draw on a Claude subscription
           # instead of API billing (setup-fragua/README.md § Credentials).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ github.token }} # gh pr diff / view / review
+          GH_TOKEN: ${{ github.token }} # exempted via --allow-env for gh; still a scrub needle
 
       # No manual scrubbing step: `fragua ci`'s CI profile scrubs the bundle at
       # export — it redacts provider-credential values + secret-named env vars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ guarantee.
 
 ### Added
 
+- **`fragua ci --allow-env <name>`** — exempt a secret-named env var from the CI
+  perimeter env-strip so a workflow's deterministic `tool` steps can use it (e.g.
+  `GH_TOKEN` for `gh pr diff/comment`). Exempts the STRIP only: the value is still
+  captured as a scrub needle, so it stays redacted from the exported bundle
+  (allow ≠ declassify). Provider credentials (`ANTHROPIC_API_KEY`, `*_API_KEY`, …)
+  are refused — they must never reach a tool subprocess. Repeat or comma-separate
+  to allow several. Lets the `pr-review` / `crowdin-review` GitHub Actions
+  authenticate `gh` without the disk-login workaround.
 - **`fragua runs explain <id>`** — new read-plane verb that synthesises a run's
   event log into a narrative: path taken (nodes + edges), per-step outcome and
   cost, snapshots captured, diff-vs-base summary (files / insertions /

--- a/packages/cli/bin/fragua.ts
+++ b/packages/cli/bin/fragua.ts
@@ -490,6 +490,10 @@ cli
   .option("--json", "Emit the event log as JSONL instead of the human render")
   .option("--provider <id>", "LLM provider override (else config defaults, else env-autodetect)")
   .option("--model <id>", "LLM model override")
+  .option(
+    "--allow-env <name>",
+    "Exempt an env var from the CI secret-strip so deterministic tool steps can use it (e.g. GH_TOKEN for gh). The value is still scrubbed from the exported bundle. Repeat or comma-separate. Provider credentials are refused.",
+  )
   .option("--cwd <path>", "Base directory for the workflow + project identity")
   .action(async (workflow: string, options: Record<string, unknown>) => {
     const pick = (key: string): string | undefined => {
@@ -503,6 +507,13 @@ cli
       console.error((err as Error).message);
       process.exit(2);
     }
+    // cac kebab→camelCases `--allow-env` to `allowEnv` and collects repeats into
+    // an array; accept comma-separated values within each too.
+    const allowEnvRaw = options["allowEnv"] as string | string[] | undefined;
+    const allowEnv = (Array.isArray(allowEnvRaw) ? allowEnvRaw : allowEnvRaw != null ? [allowEnvRaw] : [])
+      .flatMap((s) => String(s).split(","))
+      .map((s) => s.trim())
+      .filter(Boolean);
     const code = await ciCommand({
       workflow,
       ...(pick("cwd") !== undefined ? { cwd: pick("cwd")! } : {}),
@@ -512,6 +523,7 @@ cli
       ...(pick("model") !== undefined ? { model: pick("model")! } : {}),
       ...(options["json"] === true ? { json: true } : {}),
       ...(Object.keys(inputs).length > 0 ? { inputs } : {}),
+      ...(allowEnv.length > 0 ? { allowEnv } : {}),
     });
     process.exit(code);
   });

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -38,6 +38,7 @@ import {
   ciEnvDenyPredicate,
   seedCredsFromEnv,
   seedCredsFromGlobalStore,
+  unsafeAllowEnvNames,
 } from "../env-creds.ts";
 import { buildExecutorDeps } from "../executor-deps.ts";
 import { resolveProject } from "../project.ts";
@@ -65,6 +66,11 @@ export interface CiCommandOptions {
   /** Provider/model override (else config defaults, else env-autodetect). */
   provider?: string;
   model?: string;
+  /** Env var names exempted from the CI env-strip so a workflow's deterministic
+   * tool steps can reach them (e.g. GH_TOKEN for `gh`). Exempts the STRIP only —
+   * the value is still captured as a scrub needle and redacted from the exported
+   * bundle. Provider creds are refused (see {@link unsafeAllowEnvNames}). */
+  allowEnv?: string[];
   /** Base directory used to resolve the workflow + project identity. Default cwd. */
   cwd?: string;
 }
@@ -116,6 +122,14 @@ export async function ciCommand(opts: CiCommandOptions): Promise<number> {
   }
   const { dotPath, name, scope } = resolved;
 
+  const allowEnv = new Set(opts.allowEnv ?? []);
+  const unsafe = unsafeAllowEnvNames(allowEnv);
+  if (unsafe.length > 0) {
+    console.error(chalk.red(`ci: --allow-env refuses provider credential(s): ${unsafe.join(", ")}`));
+    console.error(chalk.dim("  provider keys are read directly by fragua and must never reach a tool subprocess."));
+    return CLI_EXIT.usage;
+  }
+
   let source: string;
   try {
     source = await readFile(dotPath, "utf8");
@@ -140,8 +154,8 @@ export async function ciCommand(opts: CiCommandOptions): Promise<number> {
   process.once("SIGINT", onSig);
   process.once("SIGTERM", onSig);
   const provisioner = new WorktreeProvisioner({
-    envDenyNames: ciEnvDenyNames(),
-    envDenyPredicate: ciEnvDenyPredicate(),
+    envDenyNames: ciEnvDenyNames(process.env, allowEnv),
+    envDenyPredicate: ciEnvDenyPredicate(allowEnv),
   });
   let runId: string | undefined;
   // Captured at seed time so mid-run rotation can't desync the registry.

--- a/packages/cli/src/env-creds.ts
+++ b/packages/cli/src/env-creds.ts
@@ -124,12 +124,26 @@ export function captureCiEnvSecrets(env: NodeJS.ProcessEnv = process.env): Array
  * empty-value vars ARE included — the strip is name-based, unconditional,
  * because an attacker could later assign a value to a secret-named var.
  *
+ * `allow` names (from `fragua ci --allow-env`) are exempted from the strip so a
+ * workflow's deterministic tool steps can reach them (e.g. `gh` needs GH_TOKEN).
+ * This affects ONLY the strip — an allowed var is NOT removed from the tool
+ * subprocess env, but it is STILL captured as a scrub needle (`captureCiEnvSecrets`
+ * is deliberately unaffected), so its value is redacted from the exported bundle.
+ * Allow ≠ declassify. Provider-credential names must NEVER be allowed through —
+ * guard with {@link unsafeAllowEnvNames} at the call site before passing them here.
+ *
  * @param env - defaults to `process.env`; injectable for tests.
+ * @param allow - names kept OUT of the deny set so they reach tool steps; still
+ *   scrubbed from the exported bundle. Default: none.
  */
-export function ciEnvDenyNames(env: NodeJS.ProcessEnv = process.env): Set<string> {
+export function ciEnvDenyNames(
+  env: NodeJS.ProcessEnv = process.env,
+  allow: ReadonlySet<string> = NO_ALLOW,
+): Set<string> {
   const providerVars = knownProviderVarNames();
   const result = new Set<string>();
   for (const name of Object.keys(env)) {
+    if (allow.has(name)) continue;
     if (isSecretEnvName(name, providerVars)) result.add(name);
   }
   return result;
@@ -145,10 +159,51 @@ export function ciEnvDenyNames(env: NodeJS.ProcessEnv = process.env): Set<string
  * applied at SPAWN TIME against the live env, catching any secret-named var
  * set AFTER the Set was built. The provider-var set is memoised in the closure
  * so the predicate is cheap to call on every spawn.
+ *
+ * @param allow - names kept OUT of the strip so they reach tool steps; still
+ *   scrubbed from the exported bundle (allow ≠ declassify). Default: none. See
+ *   {@link ciEnvDenyNames} — provider creds must never be allowed through.
  */
-export function ciEnvDenyPredicate(): (name: string) => boolean {
+export function ciEnvDenyPredicate(allow: ReadonlySet<string> = NO_ALLOW): (name: string) => boolean {
   const providerVars = knownProviderVarNames();
-  return (name: string) => isSecretEnvName(name, providerVars);
+  return (name: string) => !allow.has(name) && isSecretEnvName(name, providerVars);
+}
+
+/** Shared empty allow-set so the default path allocates nothing. */
+const NO_ALLOW: ReadonlySet<string> = new Set();
+
+/**
+ * Validate a `--allow-env` request: return the names that must NOT be exempted
+ * from the CI env-strip. A provider-credential var (e.g. `ANTHROPIC_API_KEY`,
+ * `ANTHROPIC_OAUTH_TOKEN`) must never reach a tool subprocess — fragua reads it
+ * directly for the provider, and a public/team-readable bundle is an
+ * exfiltration target. Generic `*_TOKEN` / `*_KEY` secrets (GH_TOKEN, …) ARE
+ * allowed through — that's the flag's purpose. The caller refuses the run when
+ * this returns a non-empty list.
+ */
+/**
+ * Provider-credential env names refused regardless of whether pi-ai's provider
+ * registry is loaded. `knownProviderVarNames()` is registration-gated — empty
+ * early in `fragua ci` and in unit tests — so the rail can't rely on it alone.
+ * These are the LLM-provider creds fragua reads directly; they must never reach
+ * a tool subprocess. (`_API_KEY` covers the shape virtually every provider key
+ * follows; the explicit names cover non-`_API_KEY` creds like the OAuth token.)
+ */
+const ALWAYS_PROVIDER_CRED: ReadonlySet<string> = new Set(["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"]);
+
+export function unsafeAllowEnvNames(allow: Iterable<string>): string[] {
+  const providerVars = knownProviderVarNames();
+  const bad: string[] = [];
+  for (const name of allow) {
+    const upper = name.toUpperCase();
+    // dynamic registry (prod) ∪ static critical set ∪ the `*_API_KEY` shape. The
+    // legitimate allow case is CI platform tokens (GH_TOKEN, …) which end in
+    // _TOKEN, never _API_KEY, so they pass.
+    if (providerVars.has(name) || ALWAYS_PROVIDER_CRED.has(upper) || upper.endsWith("_API_KEY")) {
+      bad.push(name);
+    }
+  }
+  return bad;
 }
 
 /**

--- a/packages/cli/test/env-creds.test.ts
+++ b/packages/cli/test/env-creds.test.ts
@@ -10,7 +10,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AuthStorage } from "@fragua/agent";
 import { SqliteStore } from "@fragua/store";
-import { captureCiEnvSecrets, ciEnvDenyNames, seedCredsFromEnv, seedCredsFromGlobalStore } from "../src/env-creds.ts";
+import {
+  captureCiEnvSecrets,
+  ciEnvDenyNames,
+  ciEnvDenyPredicate,
+  seedCredsFromEnv,
+  seedCredsFromGlobalStore,
+  unsafeAllowEnvNames,
+} from "../src/env-creds.ts";
 
 // Every env var the seed could read, scrubbed before each test so the
 // operator's own shell creds can't leak into assertions.
@@ -390,6 +397,54 @@ describe("ciEnvDenyNames", () => {
     const denySet = ciEnvDenyNames(env);
     expect(denySet.has("my_service_token")).toBe(true);
     expect(denySet.has("my_api_key")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --allow-env: exempt named secrets from the STRIP only (they still reach the
+// tool subprocess), while remaining scrub needles (redacted from the bundle).
+// ---------------------------------------------------------------------------
+
+describe("--allow-env (ciEnvDeny* allow-set)", () => {
+  test("(allow-name) an allowed var is dropped from the deny name set", () => {
+    const env: NodeJS.ProcessEnv = { GH_TOKEN: "ghs_token_value_12345678", OTHER_TOKEN: "other-value-12345678" };
+    const denySet = ciEnvDenyNames(env, new Set(["GH_TOKEN"]));
+    expect(denySet.has("GH_TOKEN")).toBe(false);
+    expect(denySet.has("OTHER_TOKEN")).toBe(true);
+  });
+
+  test("(allow-predicate) the spawn-time predicate stops denying an allowed var", () => {
+    const deny = ciEnvDenyPredicate(new Set(["GH_TOKEN"]));
+    expect(deny("GH_TOKEN")).toBe(false);
+    expect(deny("OTHER_TOKEN")).toBe(true);
+  });
+
+  test("(allow-still-scrubbed) an allowed var is STILL captured as a scrub needle", () => {
+    // capture is deliberately allow-agnostic: --allow-env affects the strip, not
+    // the needle set, so an allowed secret's value is still redacted from the bundle.
+    const env: NodeJS.ProcessEnv = { GH_TOKEN: "ghs_token_value_12345678" };
+    const names = captureCiEnvSecrets(env).map((c) => c.name);
+    expect(names).toContain("GH_TOKEN");
+  });
+
+  test("(allow-default) no allow-set behaves exactly as before", () => {
+    const env: NodeJS.ProcessEnv = { GH_TOKEN: "ghs_token_value_12345678" };
+    expect(ciEnvDenyNames(env).has("GH_TOKEN")).toBe(true);
+    expect(ciEnvDenyPredicate()("GH_TOKEN")).toBe(true);
+  });
+});
+
+describe("unsafeAllowEnvNames (provider-cred rail)", () => {
+  test("provider credential names are refused", () => {
+    expect(unsafeAllowEnvNames(["ANTHROPIC_API_KEY"])).toContain("ANTHROPIC_API_KEY");
+  });
+
+  test("generic secret names (GH_TOKEN) are allowed through", () => {
+    expect(unsafeAllowEnvNames(["GH_TOKEN", "GITHUB_TOKEN"])).toEqual([]);
+  });
+
+  test("mixed input returns only the provider creds", () => {
+    expect(unsafeAllowEnvNames(["GH_TOKEN", "ANTHROPIC_API_KEY"])).toEqual(["ANTHROPIC_API_KEY"]);
   });
 });
 


### PR DESCRIPTION
## Problem

`fragua ci` strips secret-named env vars (`*_TOKEN` / `*_KEY` / `*_SECRET` / …) from every tool subprocess — the perimeter control for the adversarial PR-review threat model. That also removes `GH_TOKEN`, so a token passed via the step `env:` never reaches the `gh pr diff/comment` calls `crowdin-review` / `pr_review` make. `gh` then exits non-zero — for `crowdin-review` a deterministic gate misread it as an out-of-scope verdict and hard-failed the run (frontend #10092). No `pr_review` run had executed on a strip-containing release yet, so it was a latent failure too.

## Change

`fragua ci --allow-env <name>` exempts a name from the **strip** so deterministic `tool` steps can use it (e.g. `GH_TOKEN` for `gh`). Key properties:

- **Strip only, not declassify.** `captureCiEnvSecrets` is unchanged, so an allowed var is *still* a scrub needle — redacted from the exported bundle, and a live leak still trips the fail-closed exit-80 alarm.
- **Provider creds refused.** `ANTHROPIC_API_KEY` / `*_API_KEY` / a static critical set can never be allowed through — they must never reach a subprocess. The rail is registry-independent (`knownProviderVarNames()` is registration-gated and empty early), so it holds regardless of timing.
- Repeat or comma-separate to allow several.

Threads the allow-set through `ciEnvDenyNames` / `ciEnvDenyPredicate` into the `WorktreeProvisioner`; adds the `cac` flag. `pr-review.yml` now uses `--allow-env GH_TOKEN`.

## Follow-ups
- **Version/CHANGELOG**: the `[Unreleased]` entry is added; the version bump + dated section happen at release time (merge → bump → tag `vX.Y.Z` → release).
- **Pin bump**: `pr-review.yml` (and frontend `crowdin-review.yml`) must bump their `setup-fragua` pin to the release that ships this. Until then, `--allow-env` is an unknown flag on `v0.3.1`, so **this PR's own `pr-review` check will fail** — expected, clears once released and repinned.

## Tests
`packages/cli/test/env-creds.test.ts`: allow-set drops a name from the deny set + predicate; allowed var stays a capture needle; provider creds / `*_API_KEY` refused; default path unchanged. Typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)