### PR TITLE
[release] v0.4.0

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0 # full history so the review can diff against base
 
-      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.3.1
+      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.4.0
 
       # `fragua ci` strips secret-named env (anything ending _TOKEN / _KEY / …) from
       # tool subprocesses, which removes GH_TOKEN from the `gh pr diff/view/review`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ guarantee.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-02
+
 ### Added
 
 - **`fragua ci --allow-env <name>`** — exempt a secret-named env var from the CI
@@ -159,5 +161,6 @@ back down as a portable `.fragua` bundle for local inspection and aggregation.
 - Nightly property-test suite: raised the per-test timeout to fit PBT scaling and
   deflaked timer-fragile tests (#4).
 
+[0.4.0]: https://github.com/purrgrammer/fragua/compare/v0.3.1...v0.4.0
 [0.2.0]: https://github.com/purrgrammer/fragua/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/purrgrammer/fragua/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragua",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "a local dark software forge",
   "type": "module",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/agent",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua agent layer — thin wrapper on pi-agent-core with fragua middleware",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/cli",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua CLI — run / validate / replay / resume / steer / approve / dashboard",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua orchestrator core — pure reducer, zero I/O",
   "type": "module",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/daemon",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua daemon — executor + supervisor fiber atop @fragua/store",
   "type": "module",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/server",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua HTTP server — SSE event stream, REST API for the web UI",
   "type": "module",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/store",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "SQLite-backed event store — single coordination surface for fragua",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/types",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua shared types — pi-agent-core AgentMessage plus fragua-specific declaration merges",
   "type": "module",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/web",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua web UI — Vite + React + Tailwind client for the HTTP/SSE server",
   "type": "module",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/workspace",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "fragua execution environments — local, worktree, blocklist, env-leak gate",
   "type": "module",


### PR DESCRIPTION
Release prep for **v0.4.0**.

- CHANGELOG `[Unreleased]` → `## [0.4.0] - 2026-06-02` (+ fresh empty `[Unreleased]`, compare link).
- All workspace `package.json` versions `0.3.1` → `0.4.0`.
- `pr-review.yml` `setup-fragua` pin → `v0.4.0` (the release that ships `fragua ci --allow-env`, merged in #16).

## After merge
Tag the merge commit `v0.4.0` and push it — `release.yml` builds the binaries and publishes the GitHub Release with the `## [0.4.0]` notes.

Note: this PR's own `pr-review` check will fail (it pins `v0.4.0`, which doesn't exist until the tag is pushed) — expected, clears once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)