### PR TITLE
[store,core] imported flag: derive from the imported_runs marker, not cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,10 @@ guarantee.
   retained, so imported runs display per-step cost, LLM-step labels, the
   traversal-edge overlay, and the run title correctly.
 - **Imported-run fidelity — UI operate controls**: `RunControls` now accepts an
-  `imported` prop; when true (derived from `RunDetail.imported`, set when
-  `cwd == null`) the pause/resume/cancel buttons are replaced with a read-only
-  "imported (inert)" badge, preventing dead-end operate actions on runs the
-  daemon will never dispatch.
+  `imported` prop; when true (derived from `RunDetail.imported`, set from the
+  `imported_runs` inert marker) the pause/resume/cancel buttons are replaced with
+  a read-only "imported (inert)" badge, preventing dead-end operate actions on
+  runs the daemon will never dispatch.
 
 ## [0.4.0] — 2026-06-02
 

--- a/packages/core/src/read-plane/projections.ts
+++ b/packages/core/src/read-plane/projections.ts
@@ -166,7 +166,10 @@ export function runStateToDetail(
 
   if (state.baseGitRef != null && state.baseGitRef.length > 0) detail.baseGitRef = state.baseGitRef;
   if (state.baseGitSha != null && state.baseGitSha.length > 0) detail.baseGitSha = state.baseGitSha;
-  if (state.cwd == null) detail.imported = true;
+  // Authoritative inert marker is `imported_runs` (carried on `state.imported`),
+  // NOT `cwd == null` — a legitimately-enqueued run can have a null cwd and must
+  // keep its operate controls.
+  if (state.imported === true) detail.imported = true;
 
   if (state.status === "paused_human") {
     for (let i = events.length - 1; i >= 0; i--) {

--- a/packages/store/src/run-state-queries.ts
+++ b/packages/store/src/run-state-queries.ts
@@ -69,6 +69,9 @@ export interface RunStateRow {
   inbox_status: string | null;
   accepted_sha: string | null;
   schedule_id: string | null;
+  /** 1 when the run carries the `imported_runs` inert marker, else 0. Computed
+   * by the SELECT (not a `run_state` column). */
+  imported: number;
 }
 
 /** Per-run identity + version + lastAppliedSeq + status. Returned by
@@ -93,7 +96,8 @@ const SELECT_RUN_STATE_FULL_SQL = `
          cwd, project_id, project_name, workflow_name, workflow_scope, workflow_path,
          base_git_sha, base_git_ref,
          final_git_sha, final_head_ref, diff_base_sha, change_stat,
-         inbox_status, accepted_sha, schedule_id
+         inbox_status, accepted_sha, schedule_id,
+         EXISTS (SELECT 1 FROM imported_runs i WHERE i.run_id = run_state.run_id) AS imported
     FROM run_state
    WHERE run_id = ?
 `;

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -318,6 +318,7 @@ function rowToRunState(row: RunStateRow): RunState {
     inboxStatus: row.inbox_status as InboxStatus | null,
     acceptedSha: row.accepted_sha,
     cwd: row.cwd,
+    imported: row.imported === 1,
     projectId: row.project_id,
     projectName: row.project_name,
     workflowName: row.workflow_name,
@@ -1393,7 +1394,19 @@ export class SqliteStore implements IEventStore {
    * part of the portable record, so a future table can't silently ride along.
    * Keep this in sync with schema.sql. */
   retainPortableTables(): void {
-    const portable = new Set(["schema_version", "workflows", "run_state", "events", "messages", "artifacts", "blobs"]);
+    // `imported_runs` rides along: it's the authoritative inert marker, and
+    // `getState` reads it to derive `imported`. Dropping it would both break that
+    // read and strip the inert flag from any imported run in a portable copy.
+    const portable = new Set([
+      "schema_version",
+      "workflows",
+      "run_state",
+      "events",
+      "messages",
+      "artifacts",
+      "blobs",
+      "imported_runs",
+    ]);
     const tables = this.db
       .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
       .all()

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -231,8 +231,14 @@ export interface RunState {
    * traceability). Set by `fact.run_accepted`. */
   acceptedSha: string | null;
   /** Per-machine LOCATION binding — the resolved project root on this box.
-   * `null` for runs enqueued without filesystem context (CI, tests). */
+   * `null` for runs enqueued without filesystem context (CI, tests). NOTE: a
+   * null `cwd` does NOT mean the run is imported — see `imported`. */
   cwd: string | null;
+  /** Read-derived (NOT a persisted column): true when the run carries the
+   * `imported_runs` inert marker. This — not `cwd == null` — is the authoritative
+   * "imported, never dispatched" signal (a legitimately-enqueued run can have a
+   * null `cwd`). Populated by `getState`; absent on reducer-produced states. */
+  imported?: boolean;
   /** Project IDENTITY (the committed `id`) and its display label. Stable
    * across clones / machines / imports; this — not `cwd` — is how a run
    * attributes to a project. Always present (NOT NULL in the store). */

--- a/packages/store/test/bundle.test.ts
+++ b/packages/store/test/bundle.test.ts
@@ -24,7 +24,7 @@ import {
   scrubEventPayload,
   writeTar,
 } from "../src/index.ts";
-import { freshStore, seedWorkflow } from "./helpers.ts";
+import { freshStore, seedRun, seedWorkflow } from "./helpers.ts";
 
 function untar(bytes: Uint8Array, dir: string): void {
   const tarPath = join(dir, "bundle.tar");
@@ -160,6 +160,7 @@ describe("importRunBundle", () => {
     expect(state.baseGitSha).toBe("base");
     expect(state.cwd).toBeNull(); // src had a cwd; import drops it → inert
     expect(srcState.cwd).toBe("/home/dev/proj");
+    expect(state.imported).toBe(true); // the `imported_runs` marker, not the null cwd
 
     expect(dst.getEvents(runId).length).toBe(srcEvents);
     expect(dst.getMessages(runId).length).toBe(1);
@@ -168,6 +169,18 @@ describe("importRunBundle", () => {
     // The credential did not travel.
     expect(dst.getProviderCredential("anthropic")).toBeNull();
     dst.close();
+  });
+
+  test("a cwd-less run WITHOUT the import marker is NOT flagged imported", async () => {
+    // The regression guard: `imported` keys on the `imported_runs` marker, not on
+    // a null cwd. A run enqueued without filesystem context (CI / API by sha) has
+    // a null cwd but is fully dispatchable — it must NOT read as imported.
+    const store = freshStore();
+    const runId = await seedRun(store); // enqueued with no cwd, no import marker
+    const state = store.getState(runId)!;
+    expect(state.cwd).toBeNull();
+    expect(state.imported).toBe(false);
+    store.close();
   });
 
   test("an imported run is inert - never claimed, even when it derives to queued", async () => {

--- a/packages/store/test/genesis-derive.test.ts
+++ b/packages/store/test/genesis-derive.test.ts
@@ -25,9 +25,11 @@ function deriveFromLog(runId: string, events: { type: string; payload: unknown; 
 }
 
 /** Fields the reducer doesn't own (write bookkeeping), plus the deliberately
- *  non-portable ones. Normalized away on both sides before comparing. */
+ *  non-portable ones. Normalized away on both sides before comparing.
+ *  `imported` is read-derived by `getState` (the `imported_runs` marker), not
+ *  part of the reducer projection. */
 function normalize(s: RunState): RunState {
-  return { ...s, version: 0, nextSeq: 0, lastAppliedSeq: 0, title: null, cwd: null };
+  return { ...s, version: 0, nextSeq: 0, lastAppliedSeq: 0, title: null, cwd: null, imported: false };
 }
 
 describe("genesis derivation", () => {

--- a/packages/store/test/portable-export.test.ts
+++ b/packages/store/test/portable-export.test.ts
@@ -15,7 +15,16 @@ function tableNames(store: unknown): string[] {
     .map((r) => r.name);
 }
 
-const PORTABLE = ["artifacts", "blobs", "events", "messages", "run_state", "schema_version", "workflows"];
+const PORTABLE = [
+  "artifacts",
+  "blobs",
+  "events",
+  "imported_runs",
+  "messages",
+  "run_state",
+  "schema_version",
+  "workflows",
+];
 
 describe("retainPortableTables", () => {
   test("drops credential + instance tables, keeps the portable run record", async () => {


### PR DESCRIPTION
## Why

Follow-up to #20. The review there flagged a **High** correctness bug (surfaced after merge): `runStateToDetail` derived `detail.imported = state.cwd == null`, but a null `cwd` does **not** mean a run is imported — the project's own invariant (`schema.sql` + `NOT_IMPORTED_SQL`) is that the `imported_runs` marker is authoritative, and *a legitimately-enqueued run can have a null cwd* (the server only forwards `cwd` when the request body supplies it; a client enqueuing by `workflowSha` produces a real, dispatchable run with null cwd).

Result of the bug: such a real running job was tagged `imported`, so `RunControls` hid its pause/resume/cancel behind the read-only "imported (inert)" badge — the operator couldn't control it.

## Fix

Derive `imported` from the marker, the same source dispatch/sweep/concurrency already key on:
- `SELECT_RUN_STATE_FULL_SQL` computes `EXISTS(SELECT 1 FROM imported_runs …) AS imported`;
- `rowToRunState` carries it on `RunState.imported` (read-derived; optional, absent on reducer-produced states);
- `runStateToDetail` reads `state.imported` instead of `state.cwd == null`;
- `retainPortableTables` keeps `imported_runs` — dropping it both broke the new read **and** would have stripped the inert flag from imported runs in a portable copy (re-introducing the bug there).

CHANGELOG corrected — #20's entry claimed the cwd-based derivation.

## Tests
- `bundle.test`: a cwd-less run **without** the marker reports `imported: false` (the regression guard); an imported run reports `true`.
- `genesis-derive`: the derived-vs-getState equality normalises the read-derived field.
- `bun run test:node` (2154) + `test:web` (588) + typecheck + lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)