### PR TITLE
[ci] doc-drift: single run-budget governor + install bun

### DIFF
--- a/.fragua/workflows/drift.yaml
+++ b/.fragua/workflows/drift.yaml
@@ -37,6 +37,11 @@
 
 name: drift
 goal: Cross-reference the docs against the code they describe, surface evidence-cited drift, apply the doc-fixable corrections, and open a PR for human review — drift never merges.
+# Single governor: the run-level budget. No per-step max-cost caps — on a
+# shared-thread workflow each later step re-sends the growing thread, so a
+# per-step cap trips on accumulated context rather than the step's own work
+# (it's what halted the first CI run). budget-policy: stop ends the run
+# (non-zero exit, red CI) if the whole run exceeds this.
 budget: 10.00
 budget-policy: stop
 
@@ -66,7 +71,6 @@ steps:
     thread: drift
     next: analyze
     allowed-tools: [bash]
-    max-cost: 0.25
     prompt: |
       Run the drift collector(s) for surface `${{ inputs.surface }}` via the bash tool — once each, in this order:
         - structural or both → `bun .fragua/scripts/drift/structural.ts ${{ inputs.focus }}`
@@ -79,7 +83,6 @@ steps:
     thread: drift
     next: propose
     allowed-tools: [read, grep, find]
-    max-cost: 4.50
     prompt: |
       Build a drift findings table from the collector snapshot(s) in this thread. Surface every discrepancy you can back with evidence — no speculation. Read-only (you may re-read files to confirm). Honour the `focus` hint if the snapshot carries one.
 
@@ -111,7 +114,6 @@ steps:
     thread: drift
     next: verify
     allowed-tools: [read, grep]
-    max-cost: 2.00
     prompt: |
       Turn the findings into doc edits. A finding is AUTO-FIXABLE only if editing a doc fully resolves it — wrong doc text (correct it) or missing doc text (add it). A finding needing a CODE change or human judgment (UNBACKED 'delivers today' claims, historical commit-hygiene gaps, anything where the *code* is what's wrong) is NOT auto-fixable.
 
@@ -140,7 +142,6 @@ steps:
     thread: drift
     next: apply
     allowed-tools: [read, grep]
-    max-cost: 1.25
     prompt: |
       Quality gate over the proposed findings and edits. You DROP weak items rather than failing the run — the operator approves what survives.
 
@@ -153,7 +154,6 @@ steps:
   apply:
     thread: drift
     allowed-tools: [read, edit, write]
-    max-cost: 1.00
     next: open_pr
     prompt: |
       Apply each surviving `### Edit` block (the verified set above) to its doc with the `edit` tool — one call per block, OLD as `old_string`, NEW as `new_string`, verbatim.

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -44,6 +44,10 @@ jobs:
 
       - uses: purrgrammer/fragua/.github/actions/setup-fragua@1d07104f2585ba682791896393de5e8b8622220c # v0.4.0
 
+      # The drift collectors run as `bun .fragua/scripts/drift/*.ts`; setup-fragua
+      # installs the compiled fragua binary, not the bun runtime they need.
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
       # `fragua ci` strips secret-named env (anything ending _TOKEN / _KEY / …) from
       # tool subprocesses; `--allow-env GH_TOKEN` exempts it so open_pr's `gh` calls
       # work. The value stays a scrub needle (redacted from the exported bundle).


### PR DESCRIPTION
Fixes from the first live run of the drift job ([run 26877263544](https://github.com/purrgrammer/fragua/actions/runs/26877263544) on #25 halted at `verify`).

## 1. Per-step caps → single run-budget governor
Dropped all per-step `max-cost` caps; the run-level `budget: 10.00` (`budget-policy: stop`) is now the sole governor. On a shared-`thread:` workflow every later step re-sends the growing thread, so a per-step cap trips on **accumulated context, not the step's own work** — `verify` blew its $1.25 cap on ~4M cache-read tokens while the run budget was barely touched (~$3–4 cumulative). The run budget still catches genuine overruns and halts loud (non-zero exit → red CI). Matches the "bound by run budget, not per-step caps" lesson.

## 2. Install `bun`
The collectors run as `bun .fragua/scripts/drift/*.ts`, but `setup-fragua` installs the compiled fragua binary, not the bun runtime. The first run flailed (`/bin/sh: 1: bun: not found`, exit 127) and npx-installed bun on the fly, hitting a 30s bash timeout. Added `oven-sh/setup-bun@0c5077e5` (v2, SHA-pinned) after `setup-fragua`.

## Validation
`fragua validate` clean; both YAML files parse. Re-triggered on this branch (workflow_dispatch runs the branch's version) to confirm a clean end-to-end pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)