### PR TITLE
[ci] doc-drift hardening: anon bot identity, PR-existence idempotency, pin pr-review

### DIFF
--- a/.fragua/scripts/drift/open-pr.sh
+++ b/.fragua/scripts/drift/open-pr.sh
@@ -14,8 +14,10 @@
 # never `-f`. A fixed, force-pushed branch would silently clobber any human fixup
 # commits pushed onto the drift PR between runs (the `## Manual` follow-ups the PR
 # itself invites). A per-run branch shares nothing, so there is nothing to
-# overwrite — each weekly PR is an independent snapshot. If today's branch already
-# exists upstream (a same-day re-run), its PR is open already and the run no-ops.
+# overwrite — each weekly PR is an independent snapshot. The run is idempotent on
+# PR existence: a branch whose PR is already open no-ops; a branch a prior run
+# pushed but never opened a PR for (e.g. a transient gh failure) gets its PR
+# opened on retry. Commits are attributed to the GitHub Actions bot.
 #
 #   bash open-pr.sh <open_pr:true|false>
 
@@ -42,18 +44,30 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-# Today's branch already upstream ⇒ a same-day run already opened its PR. No-op
-# rather than racing a second push — and we never force over it.
-if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-  echo "$branch already exists upstream — today's PR is open; skipping"
+# Idempotent on PR existence, not branch existence: a prior run that pushed the
+# branch but failed before opening the PR (e.g. a transient `gh` error) leaves
+# the branch upstream with no PR — a retry should OPEN the PR, not skip.
+existing_pr="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')"
+if [ -n "$existing_pr" ]; then
+  echo "PR #$existing_pr already open for $branch — nothing to do"
   exit 0
 fi
 
-git config user.name "fragua-drift"
-git config user.email "drift@users.noreply.github.com"
-git checkout -B "$branch"
-git commit -m "[docs] drift: sync docs to the code they describe"
-git push -u origin "$branch" # plain push of a fresh branch — never -f
+if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  # Branch already upstream from a prior run that never opened a PR — open the PR
+  # for the existing remote head rather than re-pushing (a fresh commit off main
+  # would be non-fast-forward, and we never force).
+  echo "$branch already upstream with no open PR — opening the PR for it"
+else
+  # Commit as the GitHub Actions bot — a system identity with no real account.
+  # A bare `<name>@users.noreply.github.com` would attribute commits to whatever
+  # GitHub user is named `<name>`; 41898282 is github-actions[bot]'s user id.
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git checkout -B "$branch"
+  git commit -m "[docs] drift: sync docs to the code they describe"
+  git push -u origin "$branch" # plain push of a fresh branch — never -f
+fi
 
 # apply writes the body; fall back to a minimal one if that step was skipped.
 if [ ! -f "$body" ]; then

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -42,11 +42,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # full history so the review can diff against base
 
-      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.4.0
+      - uses: purrgrammer/fragua/.github/actions/setup-fragua@1d07104f2585ba682791896393de5e8b8622220c # v0.4.0
 
       # `fragua ci` strips secret-named env (anything ending _TOKEN / _KEY / …) from
       # tool subprocesses, which removes GH_TOKEN from the `gh pr diff/view/review`
@@ -76,7 +76,7 @@ jobs:
       # `fragua import <download>` + `fragua runs status|events|messages <run-id>`.
       - name: Upload run bundle
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr-review-bundle-${{ github.event.pull_request.number }}
           path: ${{ runner.temp }}/pr-review.fragua


### PR DESCRIPTION
Follow-ups from the first live drift runs. Two files, no behavior change to what the job produces.

## `open-pr.sh`
- **Anonymous commit identity.** Commits now use `github-actions[bot]` (`41898282+github-actions[bot]@users.noreply.github.com`) instead of `fragua-drift <drift@users.noreply.github.com>`. The bare legacy-noreply form attributes commits to whatever real GitHub account is named `drift` — the Actions bot is a system identity with no real account, no fragua account needed, and is honest (the commit *is* made by Actions).
- **Idempotent on PR existence, not branch existence.** The first end-to-end run pushed `fragua/drift-20260603` but `gh pr create` was blocked (Actions-create-PR was off), leaving the branch upstream with no PR — and the old `skip-if-branch-exists` check would then no-op every retry forever. Now: PR already open → no-op; branch upstream but no PR → open the PR for the existing head (no re-push, never force); no branch → fresh commit + push + create.

## `pr-review.yml`
- **SHA-pin** `actions/checkout`, `setup-fragua`, `actions/upload-artifact` (it holds `ANTHROPIC_API_KEY`), matching `drift.yml`.
- **Deliberately NOT** adding auto-approve. Now that the org setting permits it, it's mechanically possible — but this job reviews an *untrusted diff*, so an `APPROVED` state could be prompt-injected and could auto-satisfy branch protection. The "bot signals, human merges" model stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)