### PR TITLE
fix: repair explain snapshot stats and token totals

### DIFF
--- a/packages/cli/src/commands/operator.ts
+++ b/packages/cli/src/commands/operator.ts
@@ -385,8 +385,12 @@ function renderExplanation(e: RunExplanation): void {
   }
 
   // ── Totals ───────────────────────────────────────────────────────────────
+  const cacheTokens = e.totals.cacheReadTokens + e.totals.cacheWriteTokens;
+  const tokenParts = `${e.totals.inputTokens}+${e.totals.outputTokens}${
+    cacheTokens > 0 ? `+${cacheTokens} cached` : ""
+  }`;
   console.log(
-    `  cost:     $${e.totals.costUsd.toFixed(4)} ${chalk.dim(`(${e.totals.inputTokens}+${e.totals.outputTokens} tok)`)}`,
+    `  cost:     $${e.totals.costUsd.toFixed(4)} ${chalk.dim(`(${tokenParts} = ${e.totals.billedTokens} tok)`)}`,
   );
   if (e.totals.durationMs != null) {
     console.log(`  duration: ${(e.totals.durationMs / 1000).toFixed(1)}s`);
@@ -839,7 +843,12 @@ export function stepsCommand(opts: StepsOptions): Promise<number> {
 }
 
 function renderStepLine(s: StepSnapshot): string {
-  const tokens = (s.cost?.input_tokens ?? 0) + (s.cost?.output_tokens ?? 0);
+  const tokens =
+    s.cost?.billed_tokens ??
+    (s.cost?.input_tokens ?? 0) +
+      (s.cost?.output_tokens ?? 0) +
+      (s.cost?.cache_read_tokens ?? 0) +
+      (s.cost?.cache_write_tokens ?? 0);
   const cost = (s.cost?.cost_usd ?? 0).toFixed(4);
   const dur = s.durationMs != null ? `${s.durationMs}` : "?";
   return (

--- a/packages/cli/test/operator-explain.test.ts
+++ b/packages/cli/test/operator-explain.test.ts
@@ -62,6 +62,80 @@ function seedCompleted(store: IEventStore, runId: string): void {
   store.appendFact(runId, [{ type: "fact.run_completed", payload: { finalNode: "n1" } }], s1.version);
 }
 
+function seedCompletedWithCachedCost(store: IEventStore, runId: string): void {
+  store.enqueueRun({ runId, workflowSha: "wf", cwd: "/tmp/repo" });
+  const s0 = store.getState(runId)!;
+  store.appendFact(
+    runId,
+    [
+      {
+        type: "fact.run_started",
+        payload: {
+          workflowSha: "wf",
+          contractVersion: s0.contractVersion,
+          startNode: "n1",
+          baseGitSha: BASE,
+          baseGitRef: "main",
+        },
+      },
+      {
+        type: "fact.node_started",
+        payload: {
+          nodeId: "n1",
+          iteration: 0,
+        },
+      },
+    ],
+    s0.version,
+  );
+  store.appendObservabilityEvents(runId, [
+    {
+      type: "llm.start",
+      payload: {
+        nodeId: "n1",
+        iteration: 0,
+        model: "claude-sonnet",
+      },
+    },
+    {
+      type: "cost.recorded",
+      payload: {
+        nodeId: "n1",
+        iteration: 0,
+        input_tokens: 24,
+        output_tokens: 4171,
+        cache_read_tokens: 10000,
+        cache_write_tokens: 200,
+        total_tokens: 14395,
+        cost_usd: 0.5002,
+      },
+    },
+  ]);
+  const s1 = store.getState(runId)!;
+  store.appendFact(
+    runId,
+    [
+      {
+        type: "fact.node_completed",
+        payload: {
+          nodeId: "n1",
+          iteration: 0,
+          tokens: 14395,
+          costUsd: 0.5002,
+          inputTokens: 24,
+          outputTokens: 4171,
+          cacheReadTokens: 10000,
+          cacheWriteTokens: 200,
+          nextNode: "exit",
+          outcomeStatus: "success",
+        },
+      },
+      { type: "fact.run_completed", payload: { finalNode: "n1" } },
+    ],
+    s1.version,
+  );
+}
+
 function seedHalted(store: IEventStore, runId: string): void {
   store.enqueueRun({ runId, workflowSha: "wf", cwd: "/tmp/repo" });
   const s0 = store.getState(runId)!;
@@ -144,6 +218,26 @@ describe("fragua runs explain", () => {
     expect(typeof parsed.totals.costUsd).toBe("number");
     expect(typeof parsed.totals.inputTokens).toBe("number");
     expect(typeof parsed.totals.outputTokens).toBe("number");
+  });
+
+  test("--json totals include cache tokens", async () => {
+    seedCompletedWithCachedCost(r.store, "ex-cache-json");
+    const code = await explainCommand({ runId: "ex-cache-json", json: true, dbPath: r.dbPath });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out()) as RunExplanation;
+    expect(parsed.totals.inputTokens).toBe(24);
+    expect(parsed.totals.outputTokens).toBe(4171);
+    expect(parsed.totals.cacheReadTokens).toBe(10000);
+    expect(parsed.totals.cacheWriteTokens).toBe(200);
+    expect(parsed.totals.billedTokens).toBe(14395);
+    expect(parsed.steps[0]!.billedTokens).toBe(14395);
+  });
+
+  test("human render includes cache tokens in the total", async () => {
+    seedCompletedWithCachedCost(r.store, "ex-cache-human");
+    const code = await explainCommand({ runId: "ex-cache-human", dbPath: r.dbPath });
+    expect(code).toBe(0);
+    expect(out()).toContain("(24+4171+10200 cached = 14395 tok)");
   });
 
   test("unknown run → exit 1", async () => {

--- a/packages/core/src/read-plane/explain.ts
+++ b/packages/core/src/read-plane/explain.ts
@@ -25,6 +25,9 @@ export interface ExplainStep {
   costUsd: number;
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  billedTokens: number;
   durationMs?: number;
   model?: string;
 }
@@ -75,6 +78,9 @@ export interface RunExplanation {
     costUsd: number;
     inputTokens: number;
     outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    billedTokens: number;
     durationMs?: number;
   };
 }
@@ -104,15 +110,15 @@ export function buildExplanation(
     commitSha: s.commitSha,
     committed: s.committed
       ? {
-          filesChanged: s.committed.files,
-          insertions: s.committed.additions,
+          filesChanged: s.committed.filesChanged,
+          insertions: s.committed.insertions,
           deletions: s.committed.deletions,
         }
       : null,
     uncommitted: s.uncommitted
       ? {
-          filesChanged: s.uncommitted.files,
-          insertions: s.uncommitted.additions,
+          filesChanged: s.uncommitted.filesChanged,
+          insertions: s.uncommitted.insertions,
           deletions: s.uncommitted.deletions,
         }
       : null,
@@ -124,6 +130,9 @@ export function buildExplanation(
   const totalCostUsd = explainSteps.reduce((sum, s) => sum + s.costUsd, 0);
   const totalInputTokens = explainSteps.reduce((sum, s) => sum + s.inputTokens, 0);
   const totalOutputTokens = explainSteps.reduce((sum, s) => sum + s.outputTokens, 0);
+  const totalCacheReadTokens = explainSteps.reduce((sum, s) => sum + s.cacheReadTokens, 0);
+  const totalCacheWriteTokens = explainSteps.reduce((sum, s) => sum + s.cacheWriteTokens, 0);
+  const totalBilledTokens = explainSteps.reduce((sum, s) => sum + s.billedTokens, 0);
   const totalDuration =
     detail.durationMs !== undefined
       ? detail.durationMs
@@ -141,6 +150,9 @@ export function buildExplanation(
       costUsd: totalCostUsd,
       inputTokens: totalInputTokens,
       outputTokens: totalOutputTokens,
+      cacheReadTokens: totalCacheReadTokens,
+      cacheWriteTokens: totalCacheWriteTokens,
+      billedTokens: totalBilledTokens,
       ...(totalDuration !== undefined ? { durationMs: totalDuration } : {}),
     },
   };
@@ -175,6 +187,14 @@ function buildSteps(events: StoredEvent[], steps: StepSnapshot[]): ExplainStep[]
       costUsd: s.cost?.cost_usd ?? 0,
       inputTokens: s.cost?.input_tokens ?? 0,
       outputTokens: s.cost?.output_tokens ?? 0,
+      cacheReadTokens: s.cost?.cache_read_tokens ?? 0,
+      cacheWriteTokens: s.cost?.cache_write_tokens ?? 0,
+      billedTokens:
+        s.cost?.billed_tokens ??
+        (s.cost?.input_tokens ?? 0) +
+          (s.cost?.output_tokens ?? 0) +
+          (s.cost?.cache_read_tokens ?? 0) +
+          (s.cost?.cache_write_tokens ?? 0),
       ...(s.durationMs !== undefined ? { durationMs: s.durationMs } : {}),
       ...(s.model !== undefined ? { model: s.model } : {}),
     };

--- a/packages/core/src/read-plane/snapshots.ts
+++ b/packages/core/src/read-plane/snapshots.ts
@@ -8,13 +8,9 @@
 // and the CLI store-client resolve identically.
 
 import type { StoredEvent } from "@fragua/store";
-import type { SnapshotCapturedData } from "@fragua/types";
+import type { SnapshotCapturedData, SnapshotStat } from "@fragua/types";
 
-export interface SnapshotStat {
-  files: number;
-  additions: number;
-  deletions: number;
-}
+export type { SnapshotStat } from "@fragua/types";
 
 /** Wire shape of one item in the scrubber list. */
 export interface SnapshotItem {
@@ -32,10 +28,7 @@ export interface SnapshotItem {
 }
 
 export function toScrubberRow(ev: StoredEvent): SnapshotItem {
-  const p = ev.payload as Partial<SnapshotCapturedData> & {
-    committed?: { files: number; additions: number; deletions: number } | null;
-    uncommitted?: { files: number; additions: number; deletions: number } | null;
-  };
+  const p = ev.payload as Partial<SnapshotCapturedData>;
 
   const nodeId = p.nodeId ?? null;
   const label: SnapshotItem["label"] =
@@ -47,8 +40,8 @@ export function toScrubberRow(ev: StoredEvent): SnapshotItem {
     label,
     commitSha: (p.commitSha as string) ?? "",
     treeSha: (p.treeSha as string) ?? "",
-    committed: (p.committed as SnapshotStat | null | undefined) ?? null,
-    uncommitted: (p.uncommitted as SnapshotStat | null | undefined) ?? null,
+    committed: p.committed ?? null,
+    uncommitted: p.uncommitted ?? null,
   };
 }
 

--- a/packages/core/test/read-plane/explain.test.ts
+++ b/packages/core/test/read-plane/explain.test.ts
@@ -135,7 +135,7 @@ describe("read-plane explain", () => {
         label: "step",
         commitSha: "a".repeat(40),
         treeSha: "b".repeat(40),
-        committed: { files: 1, additions: 5, deletions: 1 },
+        committed: { filesChanged: 1, insertions: 5, deletions: 1 },
         uncommitted: null,
       },
       {
@@ -144,7 +144,7 @@ describe("read-plane explain", () => {
         label: "terminal",
         commitSha: "c".repeat(40),
         treeSha: "d".repeat(40),
-        committed: { files: 2, additions: 8, deletions: 0 },
+        committed: { filesChanged: 2, insertions: 8, deletions: 0 },
         uncommitted: null,
       },
     ];
@@ -298,23 +298,40 @@ describe("read-plane explain", () => {
         startSeq: 1,
         nodeId: "n1",
         startedAt: new Date().toISOString(),
-        cost: { input_tokens: 200, output_tokens: 100, cost_usd: 0.005 },
+        cost: {
+          input_tokens: 200,
+          output_tokens: 100,
+          cache_read_tokens: 1000,
+          cache_write_tokens: 50,
+          billed_tokens: 1350,
+          cost_usd: 0.005,
+        },
       },
       {
         stepIdx: 1,
         startSeq: 2,
         nodeId: "n2",
         startedAt: new Date().toISOString(),
-        cost: { input_tokens: 300, output_tokens: 150, cost_usd: 0.007 },
+        cost: {
+          input_tokens: 300,
+          output_tokens: 150,
+          cache_read_tokens: 2000,
+          cache_write_tokens: 100,
+          billed_tokens: 2550,
+          cost_usd: 0.007,
+        },
       },
     ];
     const exp = buildExplanation(baseDetail(), [], [], steps);
     expect(exp.totals.costUsd).toBeCloseTo(0.012);
     expect(exp.totals.inputTokens).toBe(500);
     expect(exp.totals.outputTokens).toBe(250);
+    expect(exp.totals.cacheReadTokens).toBe(3000);
+    expect(exp.totals.cacheWriteTokens).toBe(150);
+    expect(exp.totals.billedTokens).toBe(3900);
   });
 
-  test("snapshot rows map SnapshotItem.committed.files → filesChanged", () => {
+  test("snapshot rows preserve canonical SnapshotStat fields", () => {
     const snaps: SnapshotItem[] = [
       {
         eventIdx: 5,
@@ -322,12 +339,14 @@ describe("read-plane explain", () => {
         label: "step",
         commitSha: "a".repeat(40),
         treeSha: "b".repeat(40),
-        committed: { files: 3, additions: 10, deletions: 2 },
-        uncommitted: { files: 1, additions: 2, deletions: 0 },
+        committed: { filesChanged: 3, insertions: 10, deletions: 2 },
+        uncommitted: { filesChanged: 1, insertions: 2, deletions: 0 },
       },
     ];
     const exp = buildExplanation(baseDetail(), [], snaps, []);
     expect(exp.snapshots[0]!.committed!.filesChanged).toBe(3);
+    expect(exp.snapshots[0]!.committed!.insertions).toBe(10);
     expect(exp.snapshots[0]!.uncommitted!.filesChanged).toBe(1);
+    expect(exp.snapshots[0]!.uncommitted!.insertions).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- Use the canonical `SnapshotStat` shape in the read-plane snapshot scrubber so committed/uncommitted stats keep `filesChanged` and `insertions`.
- Carry cache read/write tokens through `runs explain` step and total projections.
- Render `runs explain` and `runs steps` token counts from billed tokens so cache-heavy runs reconcile with displayed cost.

Fixes #37.

## Tests

- `bun test ./packages/core/test/read-plane/explain.test.ts ./packages/cli/test/operator-explain.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test:node`
- `bun run test:web`
- `git diff --check`
