### PR TITLE
Unify output-delimiter hash on noble-hashes SHA-256

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/agent": {
       "name": "@fragua/agent",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fragua/core": "workspace:*",
         "@fragua/store": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/cli": {
       "name": "@fragua/cli",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "bin": {
         "fragua": "./bin/fragua.ts",
       },
@@ -62,9 +62,10 @@
     },
     "packages/core": {
       "name": "@fragua/core",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fragua/types": "workspace:*",
+        "@noble/hashes": "2.2.0",
         "@sinclair/typebox": "0.34.49",
         "yaml": "2.7.0",
       },
@@ -76,7 +77,7 @@
     },
     "packages/daemon": {
       "name": "@fragua/daemon",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fragua/core": "workspace:*",
         "@fragua/store": "workspace:*",
@@ -90,7 +91,7 @@
     },
     "packages/server": {
       "name": "@fragua/server",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fragua/agent": "workspace:*",
         "@fragua/core": "workspace:*",
@@ -108,7 +109,7 @@
     },
     "packages/store": {
       "name": "@fragua/store",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fragua/types": "workspace:*",
       },
@@ -119,7 +120,7 @@
     },
     "packages/types": {
       "name": "@fragua/types",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@mariozechner/pi-agent-core": "0.71.0",
         "@mariozechner/pi-ai": "0.71.0",
@@ -130,7 +131,7 @@
     },
     "packages/web": {
       "name": "@fragua/web",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fontsource-variable/geist": "5.2.9",
         "@fragua/core": "workspace:*",
@@ -186,7 +187,7 @@
     },
     "packages/workspace": {
       "name": "@fragua/workspace",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fragua/core": "workspace:*",
         "@fragua/types": "workspace:*",
@@ -513,7 +514,7 @@
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
-    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -2399,6 +2400,8 @@
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
+    "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@radix-ui/react-accessible-icon/@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/react-accordion/@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
@@ -2820,6 +2823,8 @@
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "eventsource/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 

--- a/packages/agent/src/handler-bridge.ts
+++ b/packages/agent/src/handler-bridge.ts
@@ -6,7 +6,6 @@
 // ctx.messages + running token/cost totals, then translate the Outcome
 // into a HandlerResult the executor can commit.
 
-import { createHash } from "node:crypto";
 import {
   type EventType,
   type LlmBackend,
@@ -20,13 +19,6 @@ import { MessageTooLargeError } from "@fragua/store";
 import type { AgentMessage } from "@fragua/types";
 import { PiLlmBackend, type PiLlmBackendOptions } from "./backend.ts";
 import { syntheticThreadId } from "./thread.ts";
-
-/** SHA-256 hex — injected as the output-delimiter hash so a laundered value
- * can't forge its own closing tag without a SHA-256 preimage. Server-side only
- * (`@fragua/core` stays browser-safe and takes this via `hashOutputs`). */
-function sha256Hex(value: string): string {
-  return createHash("sha256").update(value, "utf8").digest("hex");
-}
 
 export interface MakeLlmHandlerOpts {
   /**
@@ -82,15 +74,15 @@ export function makeLlmHandler(opts: MakeLlmHandlerOpts): HandlerSpec {
     // Resolve `${{ inputs.x }}` / `${{ outputs.X.f }}` before the prompt hits
     // the LLM. Without this the agent sees the literal placeholder and every
     // workflow with an abort-on-empty guard halts on its first node.
-    // `wrapOutputs` + `hashOutputs`: interpolated outputs are delimited with a
-    // SHA-256-derived boundary so an upstream-laundered value can't pose as an
-    // instruction (substitution.ts §6.4).
+    // `wrapOutputs`: interpolated outputs are delimited with a SHA-256-derived
+    // boundary so an upstream-laundered value can't pose as an instruction
+    // (substitution.ts §6.4).
     // An unpopulated `${{ outputs.X.f }}` read FAILS CLOSED as a node `fail`
     // (routes via fail-edge / goal-gate / aborted_exit), never an uncaught throw
     // that the executor would turn into a fatal `reason:"error"` halt.
     let prompt: string;
     try {
-      prompt = substitute(rawPrompt, { args: ctx.args, wrapOutputs: true, hashOutputs: sha256Hex });
+      prompt = substitute(rawPrompt, { args: ctx.args, wrapOutputs: true });
     } catch (err) {
       if (err instanceof UnpopulatedOutputError) {
         return { kind: "transition", outcomeStatus: "fail", failureReason: err.message, tokens: 0, costUsd: 0 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@noble/hashes": "2.2.0",
     "@sinclair/typebox": "0.34.49",
     "@fragua/types": "workspace:*",
     "yaml": "2.7.0"

--- a/packages/core/src/engine/substitution.ts
+++ b/packages/core/src/engine/substitution.ts
@@ -14,6 +14,8 @@
 // Shell-safe mode wraps the substituted value in single quotes, escaping
 // embedded quotes per POSIX (close quote, escaped quote, reopen).
 
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils.js";
 import type { OutputsValue } from "../types/outputs.ts";
 import { resolveOutputRef, UnpopulatedOutputError } from "./outputs-substitution.ts";
 
@@ -38,12 +40,6 @@ export interface SubstitutionOptions {
    * `human` `text:` is read by a person. Ignored when `escapeForShell` is set.
    * See docs/proposals/structured-outputs.md §6.4. */
   wrapOutputs?: boolean;
-  /** Hash used to derive the `<fragua_output_<hash>>` boundary id when
-   * `wrapOutputs` is set. Defaults to the browser-safe `fnv1a64Hex`. Server-side
-   * callers (the agent) inject a `node:crypto` SHA-256 so break-out is a
-   * preimage problem, not an FNV fixed-point — `@fragua/core` stays browser-safe
-   * because the strong hash is supplied from outside, not imported here. */
-  hashOutputs?: (value: string) => string;
 }
 
 /** Boundary tag for an output value interpolated into a prompt. The content
@@ -52,30 +48,19 @@ export interface SubstitutionOptions {
  * conversation view) treats it as an unknown element and hides the tags rather
  * than printing a broken `</tag attr="…">` literal. Carrying the hash on the
  * close is what makes break-out a preimage problem: a value can't contain its
- * own closing tag without a preimage of `hashHex(value)`. Deterministic, so the
+ * own closing tag without a SHA-256 preimage of the value. Deterministic, so the
  * same value renders identically on replay. The `fragua_output_` prefix is what
- * the agent's standing system-prompt rule marks as data.
- *
- * `hashHex` defaults to the browser-safe FNV-1a (best-effort, fixed-point-feasible
- * under a determined attacker); server-side callers inject SHA-256 (preimage-hard)
- * — see SubstitutionOptions.hashOutputs. */
-export function wrapOutputValue(value: string, hashHex: (s: string) => string = fnv1a64Hex): string {
-  const id = hashHex(value);
+ * the agent's standing system-prompt rule marks as data. */
+export function wrapOutputValue(value: string): string {
+  const id = sha256Hex(value);
   return `<fragua_output_${id}>${value}</fragua_output_${id}>`;
 }
 
-/** FNV-1a 64-bit → 16 hex chars. Browser-safe + synchronous (core stays free of
- * `node:crypto`); the default delimiter hash, not for security. Server-side
- * callers inject SHA-256 via `hashOutputs`. */
-function fnv1a64Hex(s: string): string {
-  let hash = 0xcbf29ce484222325n;
-  const prime = 0x100000001b3n;
-  const mask = 0xffffffffffffffffn;
-  for (let i = 0; i < s.length; i++) {
-    hash = (hash ^ BigInt(s.charCodeAt(i))) & mask;
-    hash = (hash * prime) & mask;
-  }
-  return hash.toString(16).padStart(16, "0");
+/** SHA-256 of the UTF-8 bytes of `s`, hex-encoded (64 chars). Pure-JS
+ * (noble-hashes) so `@fragua/core` stays browser-safe while the delimiter id is
+ * preimage-hard — identical bytes to `node:crypto`'s `createHash("sha256")`. */
+function sha256Hex(s: string): string {
+  return bytesToHex(sha256(utf8ToBytes(s)));
 }
 
 /** Matches `${{ inputs.name }}` with surrounding whitespace tolerance.
@@ -92,7 +77,7 @@ const COMBINED_REF_RE =
   /\$\{\{\s*(?:inputs\.([a-zA-Z][a-zA-Z0-9_-]*)|outputs\.([a-zA-Z][a-zA-Z0-9_]*)\.([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)*))\s*\}\}/g;
 
 export function substitute(template: string, opts: SubstitutionOptions = {}): string {
-  const { args = {}, escapeForShell = false, wrapOutputs = false, hashOutputs } = opts;
+  const { args = {}, escapeForShell = false, wrapOutputs = false } = opts;
   const fmt = (raw: string): string => (escapeForShell ? shellQuote(raw) : raw);
   const inputs = args.inputs ?? {};
   const outputs = args.outputs ?? {};
@@ -113,7 +98,7 @@ export function substitute(template: string, opts: SubstitutionOptions = {}): st
         missing.push(whole.trim());
         return whole;
       }
-      return wrapOutputs && !escapeForShell ? wrapOutputValue(rendered, hashOutputs) : rendered;
+      return wrapOutputs && !escapeForShell ? wrapOutputValue(rendered) : rendered;
     },
   );
   if (missing.length > 0) throw new UnpopulatedOutputError([...new Set(missing)]);

--- a/packages/core/test/engine/outputs-substitution.test.ts
+++ b/packages/core/test/engine/outputs-substitution.test.ts
@@ -161,7 +161,7 @@ describe("substitute() — wrapOutputs (prompt-consumption delimiting)", () => {
     // The hash lives in the element NAME so the open/close pair is well-formed
     // markup (a markdown renderer hides the tags instead of printing a broken
     // `</tag attr="…">`). No surrounding whitespace around the value.
-    expect(result).toMatch(/^findings: <fragua_output_([0-9a-f]{16})>all good<\/fragua_output_\1>$/);
+    expect(result).toMatch(/^findings: <fragua_output_([0-9a-f]{64})>all good<\/fragua_output_\1>$/);
   });
 
   test("the boundary id is content-derived (deterministic; differs by value)", () => {
@@ -170,23 +170,21 @@ describe("substitute() — wrapOutputs (prompt-consumption delimiting)", () => {
     expect(idOf("abc")).not.toBe(idOf("abd"));
   });
 
-  test("hashOutputs injects a custom (e.g. SHA-256) boundary hash; default stays FNV", () => {
-    // Server-side callers inject a strong hash; core keeps a browser-safe default.
-    const fakeSha = (_v: string) => "a".repeat(64);
-    const wrapped = substitute("x ${{ outputs.n.v }}", {
-      args: { outputs: { n: { v: "VV" } } },
-      wrapOutputs: true,
-      hashOutputs: fakeSha,
-    });
-    expect(wrapped).toBe(`x <fragua_output_${"a".repeat(64)}>VV</fragua_output_${"a".repeat(64)}>`);
-    // Default (no hashOutputs) → the 16-hex FNV id.
-    const def = substitute("x ${{ outputs.n.v }}", { args: { outputs: { n: { v: "VV" } } }, wrapOutputs: true });
-    expect(def).toMatch(/<fragua_output_[0-9a-f]{16}>VV<\/fragua_output_[0-9a-f]{16}>/);
+  test("boundary id is a 64-hex SHA-256 (browser-safe noble-hashes, no injection)", () => {
+    // One cross-env hash everywhere — core hashes with noble-hashes SHA-256, byte
+    // -identical to `node:crypto`, so no server-side injection seam is needed.
+    const wrapped = substitute("x ${{ outputs.n.v }}", { args: { outputs: { n: { v: "VV" } } }, wrapOutputs: true });
+    expect(wrapped).toMatch(/^x <fragua_output_([0-9a-f]{64})>VV<\/fragua_output_\1>$/);
+    // SHA-256("VV") — pinned so a hash-impl swap is a visible test break.
+    expect(wrapOutputValue("VV")).toBe(
+      "<fragua_output_12fe9d97b944ffcda622a39abd67ef89d33b2ea20535254f475f37249969fb91>" +
+        "VV</fragua_output_12fe9d97b944ffcda622a39abd67ef89d33b2ea20535254f475f37249969fb91>",
+    );
   });
 
   test("the closing tag carries the same hash as the open (break-out needs a preimage)", () => {
     const wrapped = wrapOutputValue("origin/main..HEAD");
-    const m = wrapped.match(/^<fragua_output_([0-9a-f]{16})>(.*)<\/fragua_output_([0-9a-f]{16})>$/s);
+    const m = wrapped.match(/^<fragua_output_([0-9a-f]{64})>(.*)<\/fragua_output_([0-9a-f]{64})>$/s);
     if (m === null) throw new Error(`wrapped value did not match the expected tag shape: ${wrapped}`);
     const openHash = m[1]!;
     const value = m[2]!;


### PR DESCRIPTION
> Stacked on #40 (base = `feat/structured-outputs-mvp`). Merge after #40.

## What

The `<fragua_output_<hash>>` delimiter that wraps interpolated `${{ outputs.X.f }}` values had **two** hash implementations:

- a browser-safe FNV-1a *default* in `@fragua/core`, and
- a `node:crypto` SHA-256 *injected* by the agent via a `hashOutputs` option.

The live path always injected SHA-256, so the FNV default was never exercised in production and the injection seam was pure plumbing. This unifies on a single **noble-hashes SHA-256 inside core** — pure-JS, so core stays browser-safe with one strong hash in every environment.

## Not a format change

noble's SHA-256 is byte-identical to `node:crypto`'s, and the live path already used `node:crypto` SHA-256 — so the wrapped-output bytes on the wire are unchanged. This is a refactor. The only behavioral delta is that the *core default* (previously weak FNV, never hit in prod) is now strong SHA-256.

## Removes (net −19 lines)

- `hashOutputs` option on `SubstitutionOptions`
- the hash param on `wrapOutputValue`
- the FNV-1a helper in `substitution.ts`
- the agent's `node:crypto` import + injected `sha256Hex` in `handler-bridge.ts`

## Dependency

Adds `@noble/hashes` pinned exact at `2.2.0` to `@fragua/core` — audited, zero-dep, tree-shakeable. The subpath import (`@noble/hashes/sha2.js` + `utils.js`) pulls a ~48KB closure of the 1MB package; blake/argon2/sha3/scrypt/etc. are unreachable and never bundled. The pre-existing transitive `1.8.0` (from `@noble/curves`/`eciesjs`) stays nested — no version conflict.

Web Crypto (`crypto.subtle.digest`) was rejected: it's async, but `wrapOutputValue` runs synchronously inside `substitute`'s replace callback.

## Tests

`bun run ci` green — 2298 node + 607 web tests, typecheck + lint clean. The `outputs-substitution` test pins the literal SHA-256 of a sample value so a future hash-impl swap is a visible break.