### PR TITLE
[release] v0.6.0

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0 # full history so the review can diff against base
 
-      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.5.0
+      - uses: purrgrammer/fragua/.github/actions/setup-fragua@v0.6.0
 
       # `fragua ci` strips secret-named env (anything ending _TOKEN / _KEY / …) from
       # tool subprocesses, which removes GH_TOKEN from the `gh pr diff/view/review`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ guarantee.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-08
+
 ### Added
 
 - **Structured step outputs (`outputs:`) — experimental.** An `llm` step can
@@ -30,6 +32,17 @@ guarantee.
   may omit — fails closed; model it as a required field with a sentinel, or read
   the enclosing record/array whole). Bumps the workflow `ir_version` to 2
   (additive; older workflows up-convert on load).
+
+### Fixed
+
+- **`fragua explain` reports accurate snapshot and token totals.** The explain
+  view no longer miscounts per-step token usage or attaches the wrong snapshot
+  to a step — totals now reconcile with the underlying event log.
+- **`fragua run`/`runs tail` unfreezes when a HITL prompt is answered out of
+  band.** The follow stream races the interactive picker against store
+  resolution, so an answer submitted elsewhere (the Web UI, another client)
+  resolves the pending input and the tail resumes instead of hanging on the
+  local prompt.
 
 ## [0.5.0] — 2026-06-04
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragua",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "a local dark software forge",
   "type": "module",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/agent",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua agent layer — thin wrapper on pi-agent-core with fragua middleware",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua CLI — run / validate / replay / resume / steer / approve / dashboard",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua orchestrator core — pure reducer, zero I/O",
   "type": "module",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/daemon",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua daemon — executor + supervisor fiber atop @fragua/store",
   "type": "module",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua HTTP server — SSE event stream, REST API for the web UI",
   "type": "module",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/store",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "SQLite-backed event store — single coordination surface for fragua",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua shared types — pi-agent-core AgentMessage plus fragua-specific declaration merges",
   "type": "module",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua web UI — Vite + React + Tailwind client for the HTTP/SSE server",
   "type": "module",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fragua/workspace",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "fragua execution environments — local, worktree, blocklist, env-leak gate",
   "type": "module",


### PR DESCRIPTION
Cuts **v0.6.0**.

## Changelog (`## [0.6.0]`)

### Added
- **Structured step outputs (`outputs:`) — experimental.** Typed `outputs:` on `llm` steps over the shared `inputs:` type grammar, emitted via `emit_output`, read with `${{ outputs.<producer>.<field> }}` in `prompt:`/`run:`/`text:`. Fail-closed reads, native strict-mode where supported, blob spill for oversized structs, canonical JSON rendering. New validator codes `E033`/`E034`/`E035`/`W015`/`W016`. Bumps `ir_version` to 2 (additive).

### Fixed
- `fragua explain` reports accurate snapshot and token totals.
- `fragua run`/`runs tail` unfreezes when a HITL prompt is answered out of band.

## Release mechanics
- `bun run sync-version 0.6.0` — root + 9 workspace manifests in lockstep.
- Bumped the `pr-review.yml` `setup-fragua` pin to `@v0.6.0` (the release carrying `--allow-env`).
- `bun run ci` green (lint + typecheck + test:node + test:web, 607 web tests).

Merging this, then tagging `v0.6.0` on the merge commit, triggers `release.yml` (binaries + SHA256SUMS + provenance attestations from the `## [0.6.0]` changelog block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)