### PR TITLE
[cli] add --resume to ceiling-raiser verbs to raise the cap and continue in one step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ guarantee.
 
 ### Added
 
+- `--resume` flag on the ceiling-raiser verbs (`fragua runs budget`,
+  `max-retries`, `goal-gate`, `max-loops`) raises the cap and resumes the run in
+  one step, instead of leaving it paused until a separate `fragua runs resume`.
+  Without the flag the two-step behavior is unchanged, so an operator can still
+  inspect before resuming.
 - The daemon's `daemon.stopped` record now carries the leaked `runId`/`nodeId`
   pairs when the leak budget forces a shutdown (`reason: leak_limit`), and
   `fragua doctor` prints a `last exit:` line (reason, time, and the leaked

--- a/packages/cli/bin/fragua.ts
+++ b/packages/cli/bin/fragua.ts
@@ -575,9 +575,9 @@ function runsHelp(): void {
     steer    <id> <text>             nudge the next LLM call; aborts + re-dispatches
     pause    <id>                    pause a running run (resume to continue)
     priority <id> <n>                re-order a queued run (higher first)
-    budget   <id> --scope <s> --metric <m> --new-limit <n>   raise a cap, then resume
+    budget   <id> --scope <s> --metric <m> --new-limit <n>   raise a cap (--resume to continue)
 
-  Ceiling raisers (paused runs — raise the cap, then resume):
+  Ceiling raisers (paused runs — raise the cap, then resume; or pass --resume to do both):
     max-retries <id> <n> --node <id> raise one node's handler-retry cap
     goal-gate   <id> <n>             raise the goal-gate retry cap
     max-loops   <id> <n>             raise the per-run dispatch ceiling
@@ -621,6 +621,7 @@ cli
   .option("--scope <s>", "budget: scope (e.g. run)")
   .option("--metric <m>", "budget: metric (e.g. cost | tokens)")
   .option("--new-limit <n>", "budget: the raised ceiling")
+  .option("--resume", "budget/max-retries/goal-gate/max-loops: resume the run after raising the cap")
   .option("--node <id>", "max-retries / messages: the node whose retry cap to raise / scope the transcript")
   .option(
     "--summary",
@@ -815,6 +816,7 @@ cli
               ...(pickStr(options, "metric") !== undefined ? { metric: pickStr(options, "metric")! } : {}),
               ...(nl !== undefined && Number.isFinite(nl) ? { newLimit: nl } : {}),
               ...(pickStr(options, "note") !== undefined ? { note: pickStr(options, "note")! } : {}),
+              ...(options["resume"] === true ? { resume: true } : {}),
               ...discovery(options),
             }),
           );
@@ -827,6 +829,7 @@ cli
               newLimit: Number.parseInt(arg ?? "", 10),
               ...(pickStr(options, "node") !== undefined ? { nodeId: pickStr(options, "node")! } : {}),
               ...(pickStr(options, "note") !== undefined ? { note: pickStr(options, "note")! } : {}),
+              ...(options["resume"] === true ? { resume: true } : {}),
               ...discovery(options),
             }),
           );
@@ -837,6 +840,7 @@ cli
               runId: needId(),
               newLimit: Number.parseInt(arg ?? "", 10),
               ...(pickStr(options, "note") !== undefined ? { note: pickStr(options, "note")! } : {}),
+              ...(options["resume"] === true ? { resume: true } : {}),
               ...discovery(options),
             }),
           );
@@ -847,6 +851,7 @@ cli
               runId: needId(),
               newLimit: Number.parseInt(arg ?? "", 10),
               ...(pickStr(options, "note") !== undefined ? { note: pickStr(options, "note")! } : {}),
+              ...(options["resume"] === true ? { resume: true } : {}),
               ...discovery(options),
             }),
           );

--- a/packages/cli/src/commands/operator.ts
+++ b/packages/cli/src/commands/operator.ts
@@ -33,6 +33,13 @@ interface DiscoveryOpts {
   dbPath?: string;
 }
 
+function failedResume(verb: string, runId: string, capSeq: number, error: string): string {
+  return (
+    chalk.red(`${verb}: cap raised (seq ${capSeq}) but resume failed: ${error}`) +
+    chalk.dim(` — run \`fragua runs resume ${runId}\``)
+  );
+}
+
 /** Write a control intent through the plane against the local store. Checks
  * the run exists, builds + validates via the plane, commits, prints the seq. */
 function writeIntent(
@@ -56,13 +63,22 @@ function writeIntent(
       const { seq } = plane.commit(runId, built.intent);
       if (resumeAfter) {
         const resume = plane.buildResume({});
+        // Cap raise already persisted: on resume failure point at `resume`, since
+        // re-running this verb would commit the cap raise twice.
         if (!resume.ok) {
-          console.error(chalk.red(`${verb}: ${resume.error}`));
+          console.error(failedResume(verb, runId, seq, resume.error));
           return 1;
         }
-        plane.commit(runId, resume.intent);
-        console.log(chalk.green(`${verb} requested + resumed`) + chalk.dim(` (run ${runId})`));
-        return 0;
+        try {
+          const r = plane.commit(runId, resume.intent);
+          console.log(
+            chalk.green(`${verb} requested + resumed`) + chalk.dim(` (run ${runId}, intents seq ${seq}, ${r.seq})`),
+          );
+          return 0;
+        } catch (err) {
+          console.error(failedResume(verb, runId, seq, (err as Error).message));
+          return 1;
+        }
       }
       console.log(chalk.green(`${verb} requested`) + chalk.dim(` (run ${runId}, intent seq ${seq})`));
       return 0;

--- a/packages/cli/src/commands/operator.ts
+++ b/packages/cli/src/commands/operator.ts
@@ -40,6 +40,7 @@ function writeIntent(
   runId: string,
   verb: string,
   build: (plane: IntentPlane) => BuildResult,
+  resumeAfter = false,
 ): Promise<number> {
   return withStoreClient(opts, ({ store, plane }) => {
     if (store.getState(runId) == null) {
@@ -53,6 +54,16 @@ function writeIntent(
     }
     try {
       const { seq } = plane.commit(runId, built.intent);
+      if (resumeAfter) {
+        const resume = plane.buildResume({});
+        if (!resume.ok) {
+          console.error(chalk.red(`${verb}: ${resume.error}`));
+          return 1;
+        }
+        plane.commit(runId, resume.intent);
+        console.log(chalk.green(`${verb} requested + resumed`) + chalk.dim(` (run ${runId})`));
+        return 0;
+      }
       console.log(chalk.green(`${verb} requested`) + chalk.dim(` (run ${runId}, intent seq ${seq})`));
       return 0;
     } catch (err) {
@@ -750,9 +761,11 @@ export interface BudgetOptions extends DiscoveryOpts {
   metric?: string;
   newLimit?: number;
   note?: string;
+  resume?: boolean;
 }
 
-/** Raise a cap on a `paused{reason:"budget"}` run, then `resume` to continue. */
+/** Raise a cap on a `paused{reason:"budget"}` run. Pass `--resume` to continue
+ *  in one step; otherwise `resume` separately. */
 export function budgetCommand(opts: BudgetOptions): Promise<number> {
   if (opts.scope == null || opts.metric == null || opts.newLimit == null || !Number.isFinite(opts.newLimit)) {
     console.error(chalk.red("budget: --scope <s> --metric <m> --new-limit <n> required"));
@@ -764,7 +777,7 @@ export function budgetCommand(opts: BudgetOptions): Promise<number> {
     newLimit: opts.newLimit,
   };
   if (opts.note != null && opts.note.length > 0) body.note = opts.note;
-  return writeIntent(opts, opts.runId, "budget", (p) => p.buildBudget(body));
+  return writeIntent(opts, opts.runId, "budget", (p) => p.buildBudget(body), opts.resume === true);
 }
 
 export interface MaxRetriesOptions extends DiscoveryOpts {
@@ -772,9 +785,11 @@ export interface MaxRetriesOptions extends DiscoveryOpts {
   nodeId?: string;
   newLimit: number;
   note?: string;
+  resume?: boolean;
 }
 
-/** Raise one node's handler-retry cap on a `paused{reason:"max_retries"}` run, then `resume`. */
+/** Raise one node's handler-retry cap on a `paused{reason:"max_retries"}` run.
+ *  Pass `--resume` to continue in one step; otherwise `resume` separately. */
 export function maxRetriesCommand(opts: MaxRetriesOptions): Promise<number> {
   if (opts.nodeId == null || opts.nodeId.length === 0) {
     console.error(chalk.red("max-retries: --node <nodeId> required"));
@@ -789,16 +804,18 @@ export function maxRetriesCommand(opts: MaxRetriesOptions): Promise<number> {
     newLimit: opts.newLimit,
   };
   if (opts.note != null && opts.note.length > 0) body.note = opts.note;
-  return writeIntent(opts, opts.runId, "max-retries", (p) => p.buildMaxRetries(body));
+  return writeIntent(opts, opts.runId, "max-retries", (p) => p.buildMaxRetries(body), opts.resume === true);
 }
 
 export interface GoalGateOptions extends DiscoveryOpts {
   runId: string;
   newLimit: number;
   note?: string;
+  resume?: boolean;
 }
 
-/** Raise the goal-gate retry cap on a `paused{reason:"goal_gate"}` run, then `resume`. */
+/** Raise the goal-gate retry cap on a `paused{reason:"goal_gate"}` run. Pass
+ *  `--resume` to continue in one step; otherwise `resume` separately. */
 export function goalGateCommand(opts: GoalGateOptions): Promise<number> {
   if (!Number.isFinite(opts.newLimit)) {
     console.error(chalk.red("goal-gate: <newLimit> integer required"));
@@ -806,16 +823,18 @@ export function goalGateCommand(opts: GoalGateOptions): Promise<number> {
   }
   const body: { newLimit: number; note?: string } = { newLimit: opts.newLimit };
   if (opts.note != null && opts.note.length > 0) body.note = opts.note;
-  return writeIntent(opts, opts.runId, "goal-gate", (p) => p.buildGoalGate(body));
+  return writeIntent(opts, opts.runId, "goal-gate", (p) => p.buildGoalGate(body), opts.resume === true);
 }
 
 export interface MaxLoopsOptions extends DiscoveryOpts {
   runId: string;
   newLimit: number;
   note?: string;
+  resume?: boolean;
 }
 
-/** Raise the per-run dispatch ceiling on a `paused{reason:"max_loops"}` run, then `resume`. */
+/** Raise the per-run dispatch ceiling on a `paused{reason:"max_loops"}` run.
+ *  Pass `--resume` to continue in one step; otherwise `resume` separately. */
 export function maxLoopsCommand(opts: MaxLoopsOptions): Promise<number> {
   if (!Number.isFinite(opts.newLimit)) {
     console.error(chalk.red("max-loops: <newLimit> integer required"));
@@ -823,7 +842,7 @@ export function maxLoopsCommand(opts: MaxLoopsOptions): Promise<number> {
   }
   const body: { newLimit: number; note?: string } = { newLimit: opts.newLimit };
   if (opts.note != null && opts.note.length > 0) body.note = opts.note;
-  return writeIntent(opts, opts.runId, "max-loops", (p) => p.buildMaxLoops(body));
+  return writeIntent(opts, opts.runId, "max-loops", (p) => p.buildMaxLoops(body), opts.resume === true);
 }
 
 export interface LsOptions extends DiscoveryOpts {

--- a/packages/cli/test/operator-command.test.ts
+++ b/packages/cli/test/operator-command.test.ts
@@ -400,6 +400,55 @@ describe("fragua operator verbs", () => {
     expect(code).toBe(1);
   });
 
+  // ─── --resume: the ceiling-raiser also lands an intent.resume in one step
+
+  test("budget --resume: lands both intent.budget_adjusted and intent.resume", async () => {
+    seedCommitted(r.store, "rbr");
+    const code = await budgetCommand({
+      runId: "rbr",
+      scope: "run",
+      metric: "cost",
+      newLimit: 5,
+      resume: true,
+      dbPath: r.dbPath,
+    });
+    expect(code).toBe(0);
+    expect(wrote("rbr", "intent.budget_adjusted")).toBe(true);
+    expect(wrote("rbr", "intent.resume")).toBe(true);
+  });
+
+  test("max-retries --resume: lands both intent.max_retries_adjusted and intent.resume", async () => {
+    seedCommitted(r.store, "rmrr");
+    const code = await maxRetriesCommand({ runId: "rmrr", nodeId: "n1", newLimit: 5, resume: true, dbPath: r.dbPath });
+    expect(code).toBe(0);
+    expect(wrote("rmrr", "intent.max_retries_adjusted")).toBe(true);
+    expect(wrote("rmrr", "intent.resume")).toBe(true);
+  });
+
+  test("goal-gate --resume: lands both intent.goal_gate_adjusted and intent.resume", async () => {
+    seedCommitted(r.store, "rggr");
+    const code = await goalGateCommand({ runId: "rggr", newLimit: 3, resume: true, dbPath: r.dbPath });
+    expect(code).toBe(0);
+    expect(wrote("rggr", "intent.goal_gate_adjusted")).toBe(true);
+    expect(wrote("rggr", "intent.resume")).toBe(true);
+  });
+
+  test("max-loops --resume: lands both intent.max_loops_adjusted and intent.resume", async () => {
+    seedCommitted(r.store, "rmlr");
+    const code = await maxLoopsCommand({ runId: "rmlr", newLimit: 3, resume: true, dbPath: r.dbPath });
+    expect(code).toBe(0);
+    expect(wrote("rmlr", "intent.max_loops_adjusted")).toBe(true);
+    expect(wrote("rmlr", "intent.resume")).toBe(true);
+  });
+
+  test("budget without --resume: no intent.resume (default stays two-step)", async () => {
+    seedCommitted(r.store, "rbnr");
+    const code = await budgetCommand({ runId: "rbnr", scope: "run", metric: "cost", newLimit: 5, dbPath: r.dbPath });
+    expect(code).toBe(0);
+    expect(wrote("rbnr", "intent.budget_adjusted")).toBe(true);
+    expect(wrote("rbnr", "intent.resume")).toBe(false);
+  });
+
   test("max-retries: exit 0, appends intent.max_retries_adjusted", async () => {
     seedCommitted(r.store, "rmr");
     const code = await maxRetriesCommand({ runId: "rmr", nodeId: "n1", newLimit: 5, dbPath: r.dbPath });


### PR DESCRIPTION
The ceiling-raiser verbs (budget, max-retries, goal-gate, max-loops) raised the cap but didn't resume the run, despite the help text promising "raise and resume". Added an opt-in --resume flag that commits the cap-raise plus an intent.resume in one step. Without it, the two-step behavior is unchanged.

Also covers max-loops (same bug, not listed in the issue).

### Test
`fragua runs budget <id> --scope run --metric cost --new-limit 15 --resume`
On a `paused{budget}` run it raises the cap and the run continues, no second command. Unit tests assert both `intent.budget_adjusted` and intent.resume land (and that the default writes no resume).

Solves #45.