### PR TITLE
[ci,test] let --timeout govern the property suites; size the nightly for 20x

### DIFF
--- a/.github/workflows/property-nightly.yml
+++ b/.github/workflows/property-nightly.yml
@@ -3,10 +3,19 @@ name: Property tests (nightly)
 # Goes deeper than the per-PR CI: FRAGUA_PBT_RUNS multiplies every property's
 # baseline numRuns (×20 here) so rare-branch coverage of the store / daemon /
 # agent invariants (OCC, sweep, HITL durability, abort loop) gets a hard
-# nightly stress pass. The matrix shards the suite N ways for wall-clock; each
-# shard picks a fresh fast-check seed, so coverage of the long tail accumulates
-# across nights rather than re-testing one frozen seed. Runs once a day; also
-# available via workflow_dispatch for manual kicks.
+# nightly stress pass.
+#
+# The matrix does NOT partition the suite — `matrix.shard` names the step and
+# nothing else, so all five jobs run the same four packages end to end. What it
+# buys is seed diversity: each job picks a fresh fast-check seed, so five
+# independent samples of the long tail accumulate per night instead of one.
+# Wall-clock per job is therefore the FULL suite, not a fifth of it — which is
+# what `timeout-minutes` has to cover. Renaming the axis (or making it a real
+# `--shard` split) is a separate call; the "shards for wall-clock" claim that
+# used to be here was wrong, and budgeting for a fifth of the work from it is
+# how the per-test allowance ended up undersized.
+#
+# Runs once a day; also available via workflow_dispatch for manual kicks.
 
 on:
   schedule:
@@ -32,7 +41,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Property suite — shard ${{ matrix.shard }} (FRAGUA_PBT_RUNS=20×)
+      # Per-test allowance sized for THIS multiplier: at 20x the heaviest driven
+      # properties (executor-faults OCC/hang) run ~30 s locally and ~60-90 s on
+      # a runner, so 300 s is several times the real cost while still failing
+      # fast on a genuine wedge. It is the operative limit only because the
+      # tests no longer carry `test(name, fn, 60_000)` literals — that form
+      # overrides this flag, which is why raising it alone never took effect.
+      - name: Property suite — seed ${{ matrix.shard }} of 5 (FRAGUA_PBT_RUNS=20×)
         env:
           FRAGUA_PBT_RUNS: "20"
-        run: bun test --timeout 120000 ./packages/store ./packages/daemon ./packages/core ./packages/agent
+        run: bun test --timeout 300000 ./packages/store ./packages/daemon ./packages/core ./packages/agent

--- a/packages/agent/test/resume-property.test.ts
+++ b/packages/agent/test/resume-property.test.ts
@@ -206,7 +206,7 @@ describe("threaded transcript is content-invariant across daemon restart pattern
       ),
       { numRuns: pbtRuns(20) },
     );
-  }, 60_000);
+  });
 });
 
 // ───── Property 2 — boot reconstruction matches live Set ────────────────
@@ -254,7 +254,7 @@ describe("inProcessWrites boot reconstruction matches live in-process state", ()
       ),
       { numRuns: pbtRuns(25) },
     );
-  }, 60_000);
+  });
 });
 
 // ───── Property 3 — no false-positive resume within one daemon life ────
@@ -299,7 +299,7 @@ describe("resume detection never false-positives within a live daemon", () => {
       ),
       { numRuns: pbtRuns(25) },
     );
-  }, 60_000);
+  });
 });
 
 // ───── Property 4 — restart at an arbitrary turn preserves transcript ──
@@ -362,7 +362,7 @@ describe("restart-at-turn-k preserves the final transcript byte-for-byte", () =>
       }),
       { numRuns: pbtRuns(15) },
     );
-  }, 60_000);
+  });
 });
 
 // ───── Example-based anchors ────────────────────────────────────────────

--- a/packages/daemon/test/executor-faults.property.test.ts
+++ b/packages/daemon/test/executor-faults.property.test.ts
@@ -222,7 +222,7 @@ describe("executor faults — OCC conflict at the commit seam", () => {
       ),
       { numRuns: pbtFaultRuns(150) },
     );
-  }, 60_000);
+  });
 
   // A PERSISTENT conflict on a node's commits can't be absorbed: the OCC
   // controller hits its ceiling and halts the run with `occ_exhausted` — bounded
@@ -245,7 +245,7 @@ describe("executor faults — OCC conflict at the commit seam", () => {
       }),
       { numRuns: pbtFaultRuns(150) },
     );
-  }, 60_000);
+  });
 
   // Control: with no fault scheduled, the harness completes (the conflict
   // machinery isn't masking a baseline failure).
@@ -278,7 +278,7 @@ describe("executor faults — handler hang (leaked watchdog timeout)", () => {
       }),
       { numRuns: pbtFaultRuns(60) },
     );
-  }, 60_000);
+  });
 });
 
 /** Drive a generated run to mid-flight `running` (one turn → run_started), then

--- a/scripts/test-node.ts
+++ b/scripts/test-node.ts
@@ -22,7 +22,21 @@ const dirs = readdirSync("packages", { withFileTypes: true })
 const passthrough = process.argv.slice(2);
 const args = passthrough.length > 0 ? passthrough : dirs;
 
-const res = spawnSync("bun", ["test", ...args], { stdio: "inherit" });
+// Default per-test timeout. bun's built-in default is 5s, which the heaviest
+// driven properties (executor-faults, agent resume) can brush even at the 1x
+// baseline on a loaded machine. bunfig.toml has no `[test] timeout` key in bun
+// 1.2.17 — verified: it is ignored and the 5s default applies — so the floor
+// has to be set here, on the one command CLAUDE.md tells contributors to run.
+//
+// It must NOT be a per-test `test(name, fn, ms)` literal: that form OVERRIDES
+// `bun test --timeout`, so the CI workflows' larger allowances were silently
+// capped at whatever the literal said. That is what timed out the nightly.
+// Keep the wall clock a command-line concern so the workflow that scales
+// FRAGUA_PBT_RUNS can scale the time budget with it.
+const hasTimeout = args.some((a) => a === "--timeout" || a.startsWith("--timeout="));
+const timeout = hasTimeout ? [] : ["--timeout", "60000"];
+
+const res = spawnSync("bun", ["test", ...timeout, ...args], { stdio: "inherit" });
 // status is null when the child was killed by a signal (e.g. Ctrl-C) — re-raise
 // it so a SIGINT isn't reported as a generic test failure.
 if (res.signal) process.kill(process.pid, res.signal);


### PR DESCRIPTION
## The problem

The nightly property job has been red for at least two nights — [run 29989069740](https://github.com/purrgrammer/fragua/actions/runs/29989069740) and [run 30076281777](https://github.com/purrgrammer/fragua/actions/runs/30076281777), both on `444013d0`. Not counterexamples: four properties hit a per-test timeout.

It failed on **shard 1 one night and shard 2 the next**. All five matrix jobs run identical work, so that's variance against a wall that's too tight — not a broken test.

## The wall wasn't the one the workflow set

Four properties carried a `test(name, fn, 60_000)` literal. **That form overrides `bun test --timeout`.** The nightly has passed `--timeout 120000` since 163776de — the commit whose entire purpose was raising this limit — and it never took effect. Every failure reports ~60 s, not 120 s.

Proven directly:

```
test("...", async () => { await sleep(3000); }, 1000);
$ bun test --timeout 120000    →  (fail) timed out [1000.46ms]
```

The work scales; the allowance didn't. `FRAGUA_PBT_RUNS` multiplies `numRuns` 20×, while the literal stayed at whatever the 1× baseline needed. Measured on the OCC/hang properties:

| multiplier | transient OCC | persistent OCC | handler hang |
|---|---|---|---|
| 1× | 0.9 s | 1.4 s | 1.4 s |
| 5× | 4.7 s | 7.5 s | 7.3 s |
| 20× | 17.9 s | 28.5 s | 28.7 s |

Linear — and a CI runner is slow enough to push 30 s past the 60 s line.

## The fix

**Drop the literals** rather than re-tune them, so the wall clock is a command-line concern owned by the same workflow that sets the multiplier. They can't drift apart again, and the whole override trap is gone rather than re-tuned.

- **Nightly → `--timeout 300000`.** Several times the ~60-90 s these cost on a runner at 20×, still well inside `timeout-minutes` for a genuine wedge.
- **PR gate keeps `120000`** — its 3×/5× ladder measures ~27 s for the fault suites.
- **`bun run test:node` defaults to `--timeout 60000`** so dropping the literals doesn't hand local runs bun's 5 s default. `bunfig.toml` isn't an option: `[test] timeout` is ignored in bun 1.2.17 (verified — a 7 s test still dies at 5 s with `timeout = 20000` set).

I first tried scaling the timeout via a `pbtTimeoutMs()` helper alongside `pbtRuns`. It works, but biome only hugs a test callback when the third arg is a **numeric literal** — any expression reflows the whole call, which turned a 7-line fix into a 500-line reformat. Removing the arg restores the hugged form and removes the footgun outright, so that's what this does.

## Also: the matrix doesn't shard

The workflow header claimed the matrix "shards the suite N ways for wall-clock." `matrix.shard` only interpolates into the step *name* — every job runs all four packages end to end. What the matrix actually buys is **seed diversity**: five independent fast-check seeds per night.

Corrected in the comment and the step renamed to `seed N of 5`. Reading it as a fifth of the work is plausibly how the allowance came to look sufficient. Making it a real `--shard` split is a separate call — flagging, not doing.

## Verification

- With the literals gone, `--timeout 3000` now **kills** the three OCC/hang properties. It could not before — that's the control proving the flag reaches them.
- At the real nightly setting (`FRAGUA_PBT_RUNS=20 --timeout 300000`): 13 pass, 0 fail, 112 s for daemon+agent.
- PR-gate ladder (`FRAGUA_PBT_RUNS=3 FRAGUA_PBT_FAULT_RUNS=5`): 1895 pass, 0 fail.
- Full `bun run ci`: **2993 pass, 0 fail**.

## One thing I could not reproduce

`packages/agent/test/resume-property.test.ts` runs in **1.4 s at 20× locally** but timed out at 60 s on CI — a ~40× gap a slower runner doesn't explain on its own. I checked cross-file contamination (running it in the same bun process as the leaked-handler suite) and it stayed fast, so that hypothesis is out.

I can't fully account for it. The evidence still supports this fix — the literal provably capped the flag, and a different 1-of-5 identical shard failed each night — but if the nightly goes red here again, the next move is instrumenting the job (per-test timing, runner stats) rather than raising the number a third time.
